### PR TITLE
Another Round of Cleanup

### DIFF
--- a/src/DssDirectDepositAaveDai.sol
+++ b/src/DssDirectDepositAaveDai.sol
@@ -334,8 +334,7 @@ contract DssDirectDepositAaveDai {
                 fees = availableLiquidity;
             }
             pool.withdraw(address(dai), fees, address(this));
-            daiJoin.join(address(this), fees);
-            vat.move(address(this), chainlog.getAddress("MCD_VOW"), mul(fees, RAY));
+            daiJoin.join(address(chainlog.getAddress("MCD_VOW")), fees);
         }
     }
 

--- a/src/DssDirectDepositAaveDai.sol
+++ b/src/DssDirectDepositAaveDai.sol
@@ -122,7 +122,6 @@ contract DssDirectDepositAaveDai {
     constructor(address chainlog_, bytes32 ilk_, address pool_, address interestStrategy_, address adai_, address _rewardsClaimer, uint256 tau_) public {
         address vat_ = ChainlogAbstract(chainlog_).getAddress("MCD_VAT");
         address daiJoin_ = ChainlogAbstract(chainlog_).getAddress("MCD_JOIN_DAI");
-        address pauseProxy_ = ChainlogAbstract(chainlog_).getAddress("MCD_PAUSE_PROXY");
 
         // Sanity checks
         (,,,,,,,,,, address strategy,) = LendingPoolLike(pool_).getReserveData(ATokenLike(adai_).UNDERLYING_ASSET_ADDRESS());
@@ -221,7 +220,7 @@ contract DssDirectDepositAaveDai {
     }
 
     // --- Automated Rate Targetting ---
-    function calculateTargetSupply(uint256 targetInterestRate) public returns (uint256) {
+    function calculateTargetSupply(uint256 targetInterestRate) public view returns (uint256) {
         require(targetInterestRate > 0, "DssDirectDepositAaveDai/target-interest-zero");
         require(targetInterestRate <= interestStrategy.getMaxVariableBorrowRate(), "DssDirectDepositAaveDai/above-max-interest");
 

--- a/src/DssDirectDepositAaveDai.sol
+++ b/src/DssDirectDepositAaveDai.sol
@@ -345,6 +345,13 @@ contract DssDirectDepositAaveDai {
         return rewardsClaimer.claimRewards(assets, amount, king);
     }
 
+    // --- Allow DAI holders to exit during global settlement ---
+    function exit(address usr, uint256 wad) external {
+        require(wad <= 2 ** 255, "DssDirectDepositAaveDai/overflow");
+        vat.slip(ilk, msg.sender, -int256(wad));
+        require(adai.transfer(usr, wad), "DssDirectDepositAaveDai/failed-transfer");
+    }
+
     // --- Shutdown ---
     function cage() external {
         // Can shut this down if we are authed, if the vat was caged
@@ -363,6 +370,7 @@ contract DssDirectDepositAaveDai {
 
     // --- Write-off ---
     function cull() external {
+        require(vat.live() == 1, "DssDirectDepositAaveDai/no-cull-during-shutdown");
         require(live == 0, "DssDirectDepositAaveDai/live");
         require(add(tic, tau) <= block.timestamp, "DssDirectDepositAaveDai/early-cull");
         require(culled == 0, "DssDirectDepositAaveDai/already-culled");

--- a/src/DssDirectDepositAaveDai.sol
+++ b/src/DssDirectDepositAaveDai.sol
@@ -177,8 +177,8 @@ contract DssDirectDepositAaveDai {
 
         // Auths
         VatLike(vat_).hope(daiJoin_);
-        dai_.approve(pool_, uint256(-1));
-        dai_.approve(daiJoin_, uint256(-1));
+        dai_.approve(pool_, type(uint256).max);
+        dai_.approve(daiJoin_, type(uint256).max);
     }
 
     // --- Math ---

--- a/src/DssDirectDepositAaveDai.sol
+++ b/src/DssDirectDepositAaveDai.sol
@@ -138,6 +138,7 @@ contract DssDirectDepositAaveDai {
     uint256 public live = 1;
     uint256 public culled;
     uint256 public tic;         // Time until you can write off the debt [sec]
+    address public king;        // Who gets the rewards
 
     // --- Events ---
     event Rely(address indexed usr);
@@ -209,6 +210,11 @@ contract DssDirectDepositAaveDai {
             bar = data;
         } else revert("DssDirectDepositAaveDai/file-unrecognized-param");
 
+        emit File(what, data);
+    }
+    function file(bytes32 what, address data) external auth {
+        if (what == "king") king = data;
+        else revert("DssDirectDepositAaveDai/file-unrecognized-param");
         emit File(what, data);
     }
 
@@ -335,7 +341,9 @@ contract DssDirectDepositAaveDai {
 
     // --- Collect any rewards ---
     function collect(address[] memory assets, uint256 amount) external returns (uint256) {
-        return rewardsClaimer.claimRewards(assets, amount, chainlog.getAddress("MCD_PAUSE_PROXY"));
+        require(king != address(0), "DssDirectDepositAaveDai/king-not-set");
+
+        return rewardsClaimer.claimRewards(assets, amount, king);
     }
 
     // --- Shutdown ---

--- a/src/DssDirectDepositAaveDai.t.sol
+++ b/src/DssDirectDepositAaveDai.t.sol
@@ -94,7 +94,8 @@ contract DssDirectDepositAaveDaiTest is DSTest {
 
         vat.rely(address(deposit));
         vat.init(ilk);
-        vat.file(ilk, "line", 500_000_000 * RAD);
+        vat.file(ilk, "line", 5_000_000_000 * RAD);
+        vat.file("Line", vat.Line() + 5_000_000_000 * RAD);
 
         // Give us a bunch of WETH and deposit into Aave
         uint256 amt = 1_000_000 * WAD;
@@ -220,7 +221,7 @@ contract DssDirectDepositAaveDaiTest is DSTest {
         }
     }
 
-    function getBorrowRate() public returns (uint256 borrowRate) {
+    function getBorrowRate() public view returns (uint256 borrowRate) {
         (,,,, borrowRate,,,,,,,) = pool.getReserveData(address(dai));
     }
 
@@ -488,8 +489,6 @@ contract DssDirectDepositAaveDaiTest is DSTest {
     }
 
     function test_insufficient_liquidity_for_reap_fees() public {
-        uint256 currentLiquidity = dai.balanceOf(address(adai));
-
         // Lower by 50%
         uint256 targetBorrowRate = getBorrowRate() * 50 / 100;
         deposit.file("bar", targetBorrowRate);

--- a/src/DssDirectDepositAaveDai.t.sol
+++ b/src/DssDirectDepositAaveDai.t.sol
@@ -319,7 +319,7 @@ contract DssDirectDepositAaveDaiTest is DSTest {
         currentLiquidity = dai.balanceOf(address(adai));
         (uint256 pink, uint256 part) = vat.urns(ilk, address(deposit));
         deposit.cage();
-        assertTrue(!deposit.live());
+        assertEq(deposit.live(), 0);
         deposit.exec();
 
         // Should be no dai liquidity remaining as we attempt to fully unwind
@@ -356,7 +356,7 @@ contract DssDirectDepositAaveDaiTest is DSTest {
         currentLiquidity = dai.balanceOf(address(adai));
         (uint256 pink, uint256 part) = vat.urns(ilk, address(deposit));
         deposit.cage();
-        assertTrue(!deposit.live());
+        assertEq(deposit.live(), 0);
         deposit.exec();
 
         // Should be no dai liquidity remaining as we attempt to fully unwind
@@ -375,7 +375,7 @@ contract DssDirectDepositAaveDaiTest is DSTest {
         uint256 vowDai = vat.dai(vow);
         deposit.cull();
         (uint256 ink2, uint256 art2) = vat.urns(ilk, address(deposit));
-        assertTrue(deposit.culled());
+        assertEq(deposit.culled(), 1);
         assertEq(ink2, 0);
         assertEq(art2, 0);
         assertEq(vat.gem(ilk, address(deposit)), ink);


### PR DESCRIPTION
Small things:

 * DC adjustments for test as Aave market size has grown
 * Inline interfaces to `FooLike` style to match MIPs guidelines
 * bool -> uint256 to save gas
 * Allow setting the target for stkAAVE in case we move it to a management contract later
 * Dont allow `cull()` on global settlement
 * Allow DAI holders to `exit()` during GS