### PR TITLE
Fixes from Aave Team Review

### DIFF
--- a/src/DssDirectDepositAaveDai.sol
+++ b/src/DssDirectDepositAaveDai.sol
@@ -265,7 +265,7 @@ contract DssDirectDepositAaveDai {
         uint256 supplyAmount = adai.totalSupply();
         uint256 borrowAmount = sub(supplyAmount, dai.balanceOf(address(adai)));
         uint256 targetUtil;
-        if (targetInterestRate > interestStrategy.variableRateSlope1()) {
+        if (targetInterestRate > add(interestStrategy.baseVariableBorrowRate(), interestStrategy.variableRateSlope1())) {
             // Excess interest rate
             uint256 r = targetInterestRate - interestStrategy.baseVariableBorrowRate() - interestStrategy.variableRateSlope1();
             targetUtil = add(rdiv(rmul(interestStrategy.EXCESS_UTILIZATION_RATE(), r), interestStrategy.variableRateSlope2()), interestStrategy.OPTIMAL_UTILIZATION_RATE());


### PR DESCRIPTION
## Issues
- Debt calculation. In `calculateTargetSupply` Debt is computed as `borrowAmount = sub(supplyAmount, dai.balanceOf(address(aDai)))`. This will lead to imprecision due to how we are computing interest in Aave. If you look at `getNormalizedIncomed` and `getNormalizedDebt` in the `ReserveLogic` you will see that income is with linear interest and debt with compound interest. This is done to ensure that rounding will not make anyone lose dust to the contract, and when reserves are used often, the diff is small. However, it means that in Dai at the moment, there is ~18$ difference when computing from the aToken supply or looking directly at the debt. While this is only a minor issue now, we are exploring using Aave liquidity for fast withdraws from L2, which is done by minting aTokens and backing them when the challenge period is executed. With your current implementation of `borrowAmount`, the borrowed amount would increase when a user is using the quick withdraw, even though no funds are borrowed from the Pool. I suggest that you instead go to use a similar split as the `DefaultReserveInterestRateStrategy` is doing with `availableLiquidity` and `totalDebt`. The debt computation will not change for the L2 withdraw update, but we introduce an additional value that keeps track of the unbacked tokens of the reserve, this is added to the `availableLiquidity` to get the new result, rest stays the same. Naming still getting finalized on our side.
- Target utilization calculation. In `calculateTargetSupply` I think that the if statement: `if (targetInterestRate > interestStrategy.variableRateSlope1())` should be `if (targetInterestRate > interestStrategy.baseVariableBorrowRate() + interestStrategy.variableRateSlope1())`. As long as `utilizationRate <= OPTIMAL_UTILISATION_RATE` we will have that the rate is defined as `rate = base + slope1 * ratio` where `ratio = utilizationRate / OPTIMAL_UTILIZATION_RATE` → `0 <= ratio <= 1`. This means that the max value here would be `base + slope1`, so as long as the `targetRate` is below or at this value, this is the computation we need. When we go beyond `base + slope1`, the `slope2` value comes into play as `utilizationRate > OPTIMAL_UTILIZATION_RATE`. With the current impl. you may get into a case where `slope1 < targetRate < base + slope1`, which would have you try to compute `r < 0`, which in this case seem to underflow.