### PR TITLE
Add Helper Contract for Keeper Bots

### DIFF
--- a/src/DssDirectDepositAaveDai.t.sol
+++ b/src/DssDirectDepositAaveDai.t.sol
@@ -1117,9 +1117,8 @@ contract DssDirectDepositAaveDaiTest is DSTest {
 
         // Outside of both tolerance now
         assertTrue(helper.shouldExec(address(deposit), 1 * RAY / 100), "5: 1% dev.");
-        assertTrue(helper.shouldExec(address(deposit), 40 * RAY / 100), "5: 40% dev.");
-
-        deposit.exec();
+        
+        helper.conditionalExec(address(deposit), 40 * RAY / 100); // Trigger the exec here
 
         // Should be outside of both tolerance, but debt is empty so should still return false
         (uint256 daiDebt,) = vat.urns(ilk, address(deposit));

--- a/src/DssDirectDepositAaveDai.t.sol
+++ b/src/DssDirectDepositAaveDai.t.sol
@@ -22,6 +22,7 @@ import "ds-value/value.sol";
 
 import {DssDirectDepositAaveDai} from "./DssDirectDepositAaveDai.sol";
 import {DirectDepositMom} from "./DirectDepositMom.sol";
+import {DirectHelper} from "./helper/DirectHelper.sol";
 
 interface Hevm {
     function warp(uint256) external;
@@ -100,6 +101,7 @@ contract DssDirectDepositAaveDaiTest is DSTest {
     bytes32 constant ilk = "DD-DAI-A";
     DssDirectDepositAaveDai deposit;
     DirectDepositMom directDepositMom;
+    DirectHelper helper;
     DSValue pip;
 
     // Allow for a 1 BPS margin of error on interest rates
@@ -133,6 +135,7 @@ contract DssDirectDepositAaveDaiTest is DSTest {
         deposit.file("tau", 7 days);
         directDepositMom = new DirectDepositMom();
         deposit.rely(address(directDepositMom));
+        helper = new DirectHelper();
 
         // Init new collateral
         pip = new DSValue();
@@ -1082,5 +1085,52 @@ contract DssDirectDepositAaveDaiTest is DSTest {
 
         // We should be able to close out the vault completely even though ink and art do not match
         _setRelBorrowTarget(0);
+    }
+
+    function test_shouldExec() public {
+        // Move down by 25%
+        deposit.file("bar", getBorrowRate() * 7500 / 10000);
+
+        assertTrue(helper.shouldExec(address(deposit), 1 * RAY / 100), "1: 1% dev.");       // Definitely over a 1% deviation and winding room
+        assertTrue(!helper.shouldExec(address(deposit), 40 * RAY / 100), "1: 40% dev.");    // Definitely not over a 40% deviation
+
+        deposit.exec();
+
+        // Should be within tolerance for both now
+        assertTrue(!helper.shouldExec(address(deposit), 1 * RAY / 100), "2: 1% dev.");
+        assertTrue(!helper.shouldExec(address(deposit), 40 * RAY / 100), "2: 40% dev.");
+
+        // Target 2% up
+        deposit.file("bar", getBorrowRate() * 10200 / 10000);
+
+        // Should be outside of tolerance for 1% in the unwind direction
+        assertTrue(helper.shouldExec(address(deposit), 1 * RAY / 100), "3: 1% dev.");
+        assertTrue(!helper.shouldExec(address(deposit), 40 * RAY / 100), "3: 40% dev.");
+
+        deposit.exec();
+
+        assertTrue(!helper.shouldExec(address(deposit), 1 * RAY / 100), "4: 1% dev.");
+        assertTrue(!helper.shouldExec(address(deposit), 40 * RAY / 100), "4: 40% dev.");
+
+        // Unwind completely with very large +200% target
+        deposit.file("bar", getBorrowRate() * 30000 / 10000);
+
+        // Outside of both tolerance now
+        assertTrue(helper.shouldExec(address(deposit), 1 * RAY / 100), "5: 1% dev.");
+        assertTrue(helper.shouldExec(address(deposit), 40 * RAY / 100), "5: 40% dev.");
+
+        deposit.exec();
+
+        // Should be outside of both tolerance, but debt is empty so should still return false
+        assertTrue(!helper.shouldExec(address(deposit), 1 * RAY / 100), "6: 1% dev.");
+        assertTrue(!helper.shouldExec(address(deposit), 40 * RAY / 100), "6: 40% dev.");
+
+        // Set super low bar to force hitting the debt ceiling
+        deposit.file("bar", 1 * RAY / 10000);
+        deposit.exec();
+
+        // Should be outside of both tolerance, but ceiling is hit so return false
+        assertTrue(!helper.shouldExec(address(deposit), 1 * RAY / 100), "7: 1% dev.");
+        assertTrue(!helper.shouldExec(address(deposit), 40 * RAY / 100), "7: 40% dev.");
     }
 }

--- a/src/DssDirectDepositAaveDai.t.sol
+++ b/src/DssDirectDepositAaveDai.t.sol
@@ -1112,8 +1112,8 @@ contract DssDirectDepositAaveDaiTest is DSTest {
         assertTrue(!helper.shouldExec(address(deposit), 1 * RAY / 100), "4: 1% dev.");
         assertTrue(!helper.shouldExec(address(deposit), 40 * RAY / 100), "4: 40% dev.");
 
-        // Unwind completely with very large +200% target
-        deposit.file("bar", getBorrowRate() * 30000 / 10000);
+        // Unwind completely by disabling the module
+        deposit.file("bar", 0);
 
         // Outside of both tolerance now
         assertTrue(helper.shouldExec(address(deposit), 1 * RAY / 100), "5: 1% dev.");
@@ -1122,6 +1122,8 @@ contract DssDirectDepositAaveDaiTest is DSTest {
         deposit.exec();
 
         // Should be outside of both tolerance, but debt is empty so should still return false
+        (uint256 daiDebt,) = vat.urns(ilk, address(deposit));
+        log_named_uint("daiDebt", daiDebt);
         assertTrue(!helper.shouldExec(address(deposit), 1 * RAY / 100), "6: 1% dev.");
         assertTrue(!helper.shouldExec(address(deposit), 40 * RAY / 100), "6: 40% dev.");
 

--- a/src/helper/DirectHelper.sol
+++ b/src/helper/DirectHelper.sol
@@ -88,7 +88,7 @@ contract DirectHelper {
         bytes32 ilk = direct.ilk();
         InterestRateStrategyLike interestStrategy = InterestRateStrategyLike(direct.interestStrategy());
 
-        (uint256 daiDebt,) = vat.urns(ilk, address(this));
+        (uint256 daiDebt,) = vat.urns(ilk, address(direct));
         uint256 _bar = direct.bar();
         if (_bar == 0) {
             return daiDebt > 0;     // Always attempt to close out if we have debt remaining

--- a/src/helper/DirectHelper.sol
+++ b/src/helper/DirectHelper.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2021 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.6.12;
+
+interface VatLike {
+    function ilks(bytes32) external view returns (uint256, uint256, uint256, uint256, uint256);
+    function urns(bytes32, address) external view returns (uint256, uint256);
+}
+
+interface DirectLike {
+    function vat() external view returns (address);
+    function interestStrategy() external view returns (address);
+    function dai() external view returns (address);
+    function adai() external view returns (address);
+    function stableDebt() external view returns (address);
+    function variableDebt() external view returns (address);
+    function bar() external view returns (uint256);
+    function ilk() external view returns (bytes32);
+}
+
+interface TokenLike {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address) external view returns (uint256);
+    function approve(address, uint256) external returns (bool);
+    function transfer(address, uint256) external returns (bool);
+    function scaledBalanceOf(address) external view returns (uint256);
+    function decimals() external view returns (uint8);
+}
+
+interface InterestRateStrategyLike {
+    function calculateInterestRates(
+        address reserve,
+        uint256 availableLiquidity,
+        uint256 totalStableDebt,
+        uint256 totalVariableDebt,
+        uint256 averageStableBorrowRate,
+        uint256 reserveFactor
+    ) external view returns (
+        uint256,
+        uint256,
+        uint256
+    );
+}
+
+// Helper functions for keeper bots
+contract DirectHelper {
+
+    // --- Math ---
+    function _mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require(y == 0 || (z = x * y) / y == x, "DssDirectDepositAaveDai/overflow");
+    }
+    uint256 constant RAY  = 10 ** 27;
+    function _rdiv(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = _mul(x, RAY) / y;
+    }
+
+    // Use this to determine whether exec() should be called based on your interest rate deviation threshold
+    // This assumes normal operation, culled / global shutdown should be handled externally
+    // Also assumes no liquidity issues
+    function shouldExec(
+        address _direct,
+        uint256 interestRateTolerance
+    ) external view returns (bool) {
+        // IMPORTANT: this function assumes Vat rate of this ilk will always be == 1 * RAY (no fees).
+        // That's why this module converts normalized debt (art) to Vat DAI generated with a simple RAY multiplication or division
+        // This module will have an unintended behaviour if rate is changed to some other value.
+
+        DirectLike direct = DirectLike(_direct);
+        VatLike vat = VatLike(direct.vat());
+        TokenLike dai = TokenLike(direct.dai());
+        address adai = direct.adai();
+        TokenLike stableDebt = TokenLike(direct.stableDebt());
+        TokenLike variableDebt = TokenLike(direct.variableDebt());
+        bytes32 ilk = direct.ilk();
+        InterestRateStrategyLike interestStrategy = InterestRateStrategyLike(direct.interestStrategy());
+
+        (uint256 daiDebt,) = vat.urns(ilk, address(this));
+        uint256 _bar = direct.bar();
+        if (_bar == 0) {
+            return daiDebt > 0;     // Always attempt to close out if we have debt remaining
+        }
+
+        (,, uint256 currVarBorrow) = interestStrategy.calculateInterestRates(
+            adai,
+            dai.balanceOf(adai),
+            stableDebt.totalSupply(),
+            variableDebt.totalSupply(),
+            0,
+            0
+        );
+
+        uint256 deviation = _rdiv(currVarBorrow, _bar);
+        if (deviation < RAY) {
+            // Unwind case
+            return daiDebt > 0 && (RAY - deviation) > interestRateTolerance;
+        } else if (deviation > RAY) {
+            // Wind case
+            (uint256 Art,,, uint256 line,) = vat.ilks(ilk);
+            return Art*RAY < line && (deviation - RAY) > interestRateTolerance;
+        } else {
+            // No change
+            return false;
+        }
+    }
+
+}

--- a/src/helper/DirectHelper.sol
+++ b/src/helper/DirectHelper.sol
@@ -78,10 +78,10 @@ contract DirectHelper {
         bytes32 ilk = direct.ilk();
         LendingPoolLike pool = LendingPoolLike(direct.pool());
 
-        (uint256 daiDebt,) = vat.urns(ilk, address(direct));
+        (, uint256 daiDebt) = vat.urns(ilk, address(direct));
         uint256 _bar = direct.bar();
         if (_bar == 0) {
-            return daiDebt > 0;     // Always attempt to close out if we have debt remaining
+            return daiDebt > 1;     // Always attempt to close out if we have debt remaining
         }
 
         (,,,, uint256 currVarBorrow,,,,,,,) = pool.getReserveData(dai);
@@ -89,11 +89,11 @@ contract DirectHelper {
         uint256 deviation = _rdiv(currVarBorrow, _bar);
         if (deviation < RAY) {
             // Unwind case
-            return daiDebt > 0 && (RAY - deviation) > interestRateTolerance;
+            return daiDebt > 1 && (RAY - deviation) > interestRateTolerance;
         } else if (deviation > RAY) {
             // Wind case
-            (uint256 Art,,, uint256 line,) = vat.ilks(ilk);
-            return Art*RAY < line && (deviation - RAY) > interestRateTolerance;
+            (,,, uint256 line,) = vat.ilks(ilk);
+            return (daiDebt + 1)*RAY < line && (deviation - RAY) > interestRateTolerance;
         } else {
             // No change
             return false;

--- a/src/helper/DirectHelper.sol
+++ b/src/helper/DirectHelper.sol
@@ -32,15 +32,6 @@ interface DirectLike {
     function ilk() external view returns (bytes32);
 }
 
-interface TokenLike {
-    function totalSupply() external view returns (uint256);
-    function balanceOf(address) external view returns (uint256);
-    function approve(address, uint256) external returns (bool);
-    function transfer(address, uint256) external returns (bool);
-    function scaledBalanceOf(address) external view returns (uint256);
-    function decimals() external view returns (uint8);
-}
-
 interface LendingPoolLike {
     function getReserveData(address asset) external view returns (
         uint256,    // Configuration
@@ -83,7 +74,7 @@ contract DirectHelper {
 
         DirectLike direct = DirectLike(_direct);
         VatLike vat = VatLike(direct.vat());
-        TokenLike dai = TokenLike(direct.dai());
+        address dai = direct.dai();
         bytes32 ilk = direct.ilk();
         LendingPoolLike pool = LendingPoolLike(direct.pool());
 
@@ -93,7 +84,7 @@ contract DirectHelper {
             return daiDebt > 0;     // Always attempt to close out if we have debt remaining
         }
 
-        (,,,, uint256 currVarBorrow,,,,,,,) = pool.getReserveData(address(dai));
+        (,,,, uint256 currVarBorrow,,,,,,,) = pool.getReserveData(dai);
 
         uint256 deviation = _rdiv(currVarBorrow, _bar);
         if (deviation < RAY) {

--- a/src/helper/DirectHelper.sol
+++ b/src/helper/DirectHelper.sol
@@ -30,6 +30,7 @@ interface DirectLike {
     function variableDebt() external view returns (address);
     function bar() external view returns (uint256);
     function ilk() external view returns (bytes32);
+    function exec() external;
 }
 
 interface LendingPoolLike {
@@ -67,7 +68,7 @@ contract DirectHelper {
     function shouldExec(
         address _direct,
         uint256 interestRateTolerance
-    ) external view returns (bool) {
+    ) public view returns (bool) {
         // IMPORTANT: this function assumes Vat rate of this ilk will always be == 1 * RAY (no fees).
         // That's why this module converts normalized debt (art) to Vat DAI generated with a simple RAY multiplication or division
         // This module will have an unintended behaviour if rate is changed to some other value.
@@ -98,6 +99,15 @@ contract DirectHelper {
             // No change
             return false;
         }
+    }
+
+    function conditionalExec(
+        address _direct,
+        uint256 interestRateTolerance
+    ) external {
+        require(shouldExec(_direct, interestRateTolerance), "DirectHelper/not-ready");
+        
+        DirectLike(_direct).exec();
     }
 
 }


### PR DESCRIPTION
Instead of just submitting a tx every X duration this will allow keeper bots to check if a threshold has been passed which will make things much more efficient.