### PR TITLE
V2 minor testing changes

### DIFF
--- a/src/plans/D3MAaveDaiPlan.t.sol
+++ b/src/plans/D3MAaveDaiPlan.t.sol
@@ -81,6 +81,10 @@ contract D3MAaveDaiPlanTest is D3MPlanBaseTest {
         assertEq(address(adai), D3MAaveDaiPlan(d3mTestPlan).adai());
     }
 
+    function test_sets_dai_value() public {
+        assertEq(address(D3MAaveDaiPlan(d3mTestPlan).dai()), address(dai));
+    }
+
     function test_sets_stableDebt() public {
         (,,,,,,,, address stableDebt,,,) = LendingPoolLike(aavePool).getReserveData(address(dai));
 

--- a/src/plans/D3MPlanBase.t.sol
+++ b/src/plans/D3MPlanBase.t.sol
@@ -93,10 +93,6 @@ contract D3MPlanBaseTest is DSTest {
         d3mTestPlan = address(new D3MPlanBase(address(dai)));
     }
 
-    function test_sets_dai_value() public {
-        assertEq(D3MPlanBase(d3mTestPlan).dai(), address(dai));
-    }
-
     function test_sets_creator_as_ward() public {
         assertEq(D3MPlanBase(d3mTestPlan).wards(address(this)), 1);
     }

--- a/src/pools/D3MAaveDaiPool.t.sol
+++ b/src/pools/D3MAaveDaiPool.t.sol
@@ -156,6 +156,10 @@ contract D3MAaveDaiPoolTest is D3MPoolBaseTest {
         D3MAaveDaiPool(d3mTestPool).rely(hub);
     }
 
+    function test_sets_dai_value() public {
+        assertEq(address(D3MAaveDaiPool(d3mTestPool).asset()), address(dai));
+    }
+
     function test_can_file_king() public {
         assertEq(D3MAaveDaiPool(d3mTestPool).king(), address(0));
 

--- a/src/pools/D3MAaveDaiPool.t.sol
+++ b/src/pools/D3MAaveDaiPool.t.sol
@@ -153,7 +153,6 @@ contract D3MAaveDaiPoolTest is D3MPoolBaseTest {
         address hub = address(new FakeHub());
 
         d3mTestPool = address(new D3MAaveDaiPool(hub, address(dai), address(aavePool), rewardsClaimer));
-        D3MAaveDaiPool(d3mTestPool).rely(hub);
     }
 
     function test_sets_dai_value() public {

--- a/src/pools/D3MPoolBase.t.sol
+++ b/src/pools/D3MPoolBase.t.sol
@@ -160,10 +160,6 @@ contract D3MPoolBaseTest is DSTest {
         assertTrue(false);
     }
 
-    function test_sets_dai_value() public {
-        assertEq(address(D3MPoolBase(d3mTestPool).asset()), address(dai));
-    }
-
     function test_sets_creator_as_ward() public {
         assertEq(D3MPoolBase(d3mTestPool).wards(address(this)), 1);
     }


### PR DESCRIPTION
Apart from these small changes I think we should move `D3MAaveDai.t.sol` to `tests` folder (as it is not really related to the `pools` folder).
@iamchrissmith I didn't want to do that myself to avoid inserting noise, suggest you maybe do it on `V2` branch.