### PR TITLE
Overriding fail tests

### DIFF
--- a/src/pools/D3MAavePool.t.sol
+++ b/src/pools/D3MAavePool.t.sol
@@ -200,6 +200,11 @@ contract D3MAavePoolTest is D3MPoolBaseTest {
         assertEq(code, 0);
     }
 
+    function testFail_deposit_not_hub() public override {
+        D3MTestGem(address(adai)).rely(address(aavePool));
+        D3MAavePool(d3mTestPool).deposit(1);
+    }
+
     function test_withdraw_calls_lending_pool_withdraw() public {
         D3MAavePool(d3mTestPool).file("hub", address(this));
         D3MAavePool(d3mTestPool).withdraw(1);
@@ -207,6 +212,10 @@ contract D3MAavePoolTest is D3MPoolBaseTest {
         assertEq(asset, address(dai));
         assertEq(amt, 1);
         assertEq(dst, address(this));
+    }
+
+    function testFail_withdraw_not_hub() public override {
+        D3MAavePool(d3mTestPool).withdraw(1);
     }
 
     function test_withdraw_calls_lending_pool_withdraw_vat_caged() public {
@@ -257,6 +266,12 @@ contract D3MAavePoolTest is D3MPoolBaseTest {
         assertEq(adai.balanceOf(d3mTestPool), 0);
     }
 
+    function testFail_transfer_not_hub() public override {
+        uint256 tokens = adai.totalSupply();
+        adai.transfer(d3mTestPool, tokens);
+        D3MAavePool(d3mTestPool).transfer(address(this), tokens);
+    }
+
     function test_transfer_adai_vat_caged() public {
         uint256 tokens = adai.totalSupply();
         adai.transfer(d3mTestPool, tokens);
@@ -281,6 +296,20 @@ contract D3MAavePoolTest is D3MPoolBaseTest {
 
         assertEq(adai.balanceOf(address(this)), tokens);
         assertEq(adai.balanceOf(d3mTestPool), 0);
+    }
+
+    function testFail_quit_no_auth() public override {
+        uint256 tokens = adai.totalSupply();
+        adai.transfer(d3mTestPool, tokens);
+        D3MAavePool(d3mTestPool).deny(address(this));
+        D3MAavePool(d3mTestPool).quit(address(this));
+    }
+
+    function testFail_quit_vat_caged() public override {
+        uint256 tokens = adai.totalSupply();
+        adai.transfer(d3mTestPool, tokens);
+        FakeVat(vat).cage();
+        D3MAavePool(d3mTestPool).quit(address(this));
     }
 
     function test_assetBalance_gets_adai_balanceOf_pool() public {

--- a/src/pools/D3MPoolBase.t.sol
+++ b/src/pools/D3MPoolBase.t.sol
@@ -136,7 +136,7 @@ contract FakeHub {
     }
 }
 
-contract D3MPoolBaseTest is DSTest {
+abstract contract D3MPoolBaseTest is DSTest {
     uint256 constant WAD = 10**18;
 
     Hevm hevm;
@@ -250,27 +250,15 @@ contract D3MPoolBaseTest is DSTest {
         D3MPoolBase(d3mTestPool).file("fail", address(123));
     }
 
-    function testFail_deposit_not_hub() public {
-        D3MPoolBase(d3mTestPool).deposit(1);
-    }
+    function testFail_deposit_not_hub() public virtual;
 
-    function testFail_withdraw_not_hub() public {
-        D3MPoolBase(d3mTestPool).withdraw(1);
-    }
+    function testFail_withdraw_not_hub() public virtual;
 
-    function testFail_transfer_not_hub() public {
-        D3MPoolBase(d3mTestPool).transfer(address(this), 0);
-    }
+    function testFail_transfer_not_hub() public virtual;
 
-    function testFail_quit_no_auth() public {
-        D3MPoolBase(d3mTestPool).deny(address(this));
-        D3MPoolBase(d3mTestPool).quit(address(this));
-    }
+    function testFail_quit_no_auth() public virtual;
 
-    function testFail_quit_vat_caged() public {
-        FakeVat(vat).cage();
-        D3MPoolBase(d3mTestPool).quit(address(this));
-    }
+    function testFail_quit_vat_caged() public virtual;
 
     function test_implements_preDebtChange() public {
         D3MPoolBase(d3mTestPool).preDebtChange("test");


### PR DESCRIPTION
With the current deposit/withdraw/transfer/quit fail tests in base test contract, some of them do not actually set the initial conditions for the test to pass (e.g testFail_deposit_not_hub fails even if hub is relied in the pool).
Fixing that needs aave specific code (`D3MTestGem(address(adai)).rely(address(aavePool));`).
Same situation exists with Compound for some of these fail tests.

Therefore I made these tests virtual in base, and moved the implementation back to D3MAaavePool.t.sol.
This way we don't forget to implement these tests for each platform.