### PR TITLE
Fix aave random failures

### DIFF
--- a/src/tests/integration/D3MAave.t.sol
+++ b/src/tests/integration/D3MAave.t.sol
@@ -831,10 +831,12 @@ contract D3MAaveTest is DSSTest {
         assertEq(vat.gem(ilk, address(end)), amountSupplied / 2);
         assertGt(adai.balanceOf(address(d3mAavePool)), amountSupplied / 2);
         if (originalSin + part * RAY >= originalDai + (amountSupplied / 2) * RAY) {
-            assertEqApprox(vat.sin(vow), originalSin + part * RAY - originalDai - (amountSupplied / 2) * RAY, (10 * RAY));
+            // rounding may affect twice, and multiplied by RAY to be compared with sin
+            assertEqApprox(vat.sin(vow), originalSin + part * RAY - originalDai - (amountSupplied / 2) * RAY, (2 * RAY));
             assertEq(vat.dai(vow), 0);
         } else {
-            assertEqApprox(vat.dai(vow), originalDai + (amountSupplied / 2) * RAY - originalSin - part * RAY, (10 * RAY));
+            // rounding may affect twice, and multiplied by RAY to be compared with sin
+            assertEqApprox(vat.dai(vow), originalDai + (amountSupplied / 2) * RAY - originalSin - part * RAY, (2 * RAY));
             assertEq(vat.sin(vow), 0);
         }
 

--- a/src/tests/integration/D3MAave.t.sol
+++ b/src/tests/integration/D3MAave.t.sol
@@ -340,8 +340,8 @@ contract D3MAaveTest is DSSTest {
         d3mHub.exec(ilk);
 
         (ink, art) = vat.urns(ilk, address(d3mAavePool));
-        assertEq(ink, 0);
-        assertEq(art, 0);
+        assertEqRoundingAgainst(ink, 0);
+        assertEqRoundingAgainst(art, 0);
     }
 
     function test_target_increase_insufficient_liquidity() public {
@@ -831,10 +831,10 @@ contract D3MAaveTest is DSSTest {
         assertEq(vat.gem(ilk, address(end)), amountSupplied / 2);
         assertGt(adai.balanceOf(address(d3mAavePool)), amountSupplied / 2);
         if (originalSin + part * RAY >= originalDai + (amountSupplied / 2) * RAY) {
-            assertEqApprox(vat.sin(vow), originalSin + part * RAY - originalDai - (amountSupplied / 2) * RAY, RAY);
+            assertEqApprox(vat.sin(vow), originalSin + part * RAY - originalDai - (amountSupplied / 2) * RAY, (10 * RAY));
             assertEq(vat.dai(vow), 0);
         } else {
-            assertEqApprox(vat.dai(vow), originalDai + (amountSupplied / 2) * RAY - originalSin - part * RAY, RAY);
+            assertEqApprox(vat.dai(vow), originalDai + (amountSupplied / 2) * RAY - originalSin - part * RAY, (10 * RAY));
             assertEq(vat.sin(vow), 0);
         }
 
@@ -1038,7 +1038,7 @@ contract D3MAaveTest is DSSTest {
         d3mHub.exec(ilk);
 
         (ink, ) = vat.urns(ilk, address(d3mAavePool));
-        assertEq(ink, 0);
+        assertEqRoundingAgainst(ink, 0);
     }
 
     function test_set_tau_not_caged() public {
@@ -1085,8 +1085,8 @@ contract D3MAaveTest is DSSTest {
         assertEq(vat.vice(), viceBefore);
         assertEq(vat.sin(vow), sinBefore);
         assertEq(vat.dai(vow), vowDaiBefore);
-        assertEq(dai.balanceOf(address(adai)), adaiDaiBalanceBefore);
-        assertEq(adai.balanceOf(address(d3mAavePool)), poolAdaiBalanceBefore);
+        assertEqRoundingAgainst(dai.balanceOf(address(adai)), adaiDaiBalanceBefore);
+        assertEqApprox(adai.balanceOf(address(d3mAavePool)), poolAdaiBalanceBefore, 2); // rounding may affect twice
 
         // We should be able to close out the vault completely even though ink and art do not match
         // _setRelBorrowTarget(0);
@@ -1095,13 +1095,13 @@ contract D3MAaveTest is DSSTest {
         d3mHub.exec(ilk);
 
         (ink, art) = vat.urns(ilk, address(d3mAavePool));
-        assertEq(ink, 0);
-        assertEq(art, 0);
+        assertEqRoundingAgainst(ink, 0);
+        assertEqRoundingAgainst(art, 0);
         assertEq(vat.gem(ilk, address(d3mAavePool)), 0);
         assertEq(vat.vice(), viceBefore);
         assertEq(vat.sin(vow), sinBefore);
         assertEq(vat.dai(vow), vowDaiBefore + 10 * RAD);
-        assertEq(dai.balanceOf(address(adai)), adaiDaiBalanceInitial);
+        assertEqRoundingAgainst(dai.balanceOf(address(adai)), adaiDaiBalanceInitial);
         assertEq(adai.balanceOf(address(d3mAavePool)), 0);
     }
 
@@ -1138,21 +1138,21 @@ contract D3MAaveTest is DSSTest {
         assertEq(vat.vice(), viceBefore);
         assertEq(vat.sin(vow), sinBefore);
         assertEq(vat.dai(vow), vowDaiBefore);
-        assertEq(dai.balanceOf(address(adai)), adaiDaiBalanceBefore);
-        assertEq(adai.balanceOf(address(d3mAavePool)), poolAdaiBalanceBefore);
+        assertEqRoundingAgainst(dai.balanceOf(address(adai)), adaiDaiBalanceBefore);
+        assertEqRoundingAgainst(adai.balanceOf(address(d3mAavePool)), poolAdaiBalanceBefore);
 
         d3mHub.exec(ilk);
 
         (ink, art) = vat.urns(ilk, address(d3mAavePool));
-        assertEq(ink, pink);
-        assertEq(art, part);
+        assertEqRoundingAgainst(ink, pink);
+        assertEqRoundingAgainst(art, part);
         assertEq(ink, art);
         assertEq(vat.gem(ilk, address(d3mAavePool)), gemBefore);
         assertEq(vat.vice(), viceBefore);
         assertEq(vat.sin(vow), sinBefore);
         assertEq(vat.dai(vow), vowDaiBefore + 10 * RAD);
-        assertEq(dai.balanceOf(address(adai)), adaiDaiBalanceBefore);
-        assertEq(adai.balanceOf(address(d3mAavePool)), poolAdaiBalanceBefore);
+        assertEqRoundingAgainst(dai.balanceOf(address(adai)), adaiDaiBalanceBefore);
+        assertEqApprox(adai.balanceOf(address(d3mAavePool)), poolAdaiBalanceBefore, 2); // rounding may affect twice
 
         // Raise target a little to trigger unwind
         //_setRelBorrowTarget(12500);
@@ -1176,14 +1176,14 @@ contract D3MAaveTest is DSSTest {
         d3mHub.exec(ilk);
 
         (ink, art) = vat.urns(ilk, address(d3mAavePool));
-        assertEq(ink, pink);
-        assertEq(art, part);
+        assertEqRoundingAgainst(ink, pink);
+        assertEqRoundingAgainst(art, part);
         assertEq(ink, art);
         assertEq(vat.gem(ilk, address(d3mAavePool)), gemBefore);
         assertEq(vat.vice(), viceBefore);
         assertEq(vat.sin(vow), sinBefore);
         assertEq(vat.dai(vow), vowDaiBefore + 10 * RAD);
-        assertEq(dai.balanceOf(address(adai)), adaiDaiBalanceBefore);
-        assertEq(adai.balanceOf(address(d3mAavePool)), poolAdaiBalanceBefore);
+        assertEqRoundingAgainst(dai.balanceOf(address(adai)), adaiDaiBalanceBefore);
+        assertEqApprox(adai.balanceOf(address(d3mAavePool)), poolAdaiBalanceBefore, 2); // rounding may affect twice
     }
 }


### PR DESCRIPTION
**After these fixes I ran the tests in a loop for 4 hours using the following command and got no more failures:**

`while ETH_RPC_URL=http://127.0.0.1:8546 seth block "latest" number && DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=200 dapp --use solc:0.8.14 test --rpc-url=http://127.0.0.1:8546 --match=  ; do :; done`

/////////////////////////////

**For future reference - failed tests and block numbers:**

- handled - [FAIL] test_bar_zero() (gas: 703208)	- DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=200 dapp --use solc:0.8.14 test --rpc-url=http://127.0.0.1:8546 --match=**test_bar_zero** -vv --rpc-block=**15038698**

- handled - test_fully_unwind_debt_paid_back	- DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=200 dapp --use solc:0.8.14 test --rpc-url=http://127.0.0.1:8546 --match=**test_fully_unwind_debt_paid_back** -vv --rpc-block=**15038698**

- handled - test_wind_partial_unwind_wind_debt_paid_back - DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=200 dapp --use solc:0.8.14 test --rpc-url=http://127.0.0.1:8546 --match=**test_wind_partial_unwind_wind_debt_paid_bac**k -vv --rpc-block=**15038842**

- handled - test_unwind_culled_then_mcd_caged - DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=200 dapp --use solc:0.8.14 test --rpc-url=http://127.0.0.1:8546 --match=**test_unwind_culled_then_mcd_caged** -vv --rpc-block=**15038960** 

- handled  - time ETH_RPC_URL=http://127.0.0.1:8546 seth block "latest" number && DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=200 dapp --use solc:0.8.14 test --rpc-url=http://127.0.0.1:8546 --rpc-block=**15043936** --match=**test_direct_deposit_mom** -vv