### PR TITLE
cmooney-20220805: Fixes for CS 5.4 Inconsistencies

### DIFF
--- a/src/plans/D3MAavePlan.sol
+++ b/src/plans/D3MAavePlan.sol
@@ -66,8 +66,6 @@ contract D3MAavePlan is ID3MPlan {
     address         public immutable adai;
     uint256         public immutable adaiRevision;
 
-    uint256 internal constant MAX_BORROW_RATE = RAY; // 100%
-
     // --- Events ---
     event Rely(address indexed usr);
     event Deny(address indexed usr);
@@ -120,10 +118,8 @@ contract D3MAavePlan is ID3MPlan {
     }
 
     function file(bytes32 what, uint256 data) external auth {
-        if (what == "bar") {
-            require(data <= MAX_BORROW_RATE, "D3MAavePlan/bar-too-high");
-            bar = data;
-        } else revert("D3MAavePlan/file-unrecognized-param");
+        if (what == "bar") bar = data;
+        else revert("D3MAavePlan/file-unrecognized-param");
         emit File(what, data);
     }
     function file(bytes32 what, address data) external auth {

--- a/src/plans/D3MAavePlan.sol
+++ b/src/plans/D3MAavePlan.sol
@@ -66,6 +66,8 @@ contract D3MAavePlan is ID3MPlan {
     address         public immutable adai;
     uint256         public immutable adaiRevision;
 
+    uint256 internal constant MAX_BORROW_RATE = RAY; // 100%
+
     // --- Events ---
     event Rely(address indexed usr);
     event Deny(address indexed usr);
@@ -118,8 +120,10 @@ contract D3MAavePlan is ID3MPlan {
     }
 
     function file(bytes32 what, uint256 data) external auth {
-        if (what == "bar") bar = data;
-        else revert("D3MAavePlan/file-unrecognized-param");
+        if (what == "bar") {
+            require(data <= MAX_BORROW_RATE, "D3MAavePlan/bar-too-high");
+            bar = data;
+        } else revert("D3MAavePlan/file-unrecognized-param");
         emit File(what, data);
     }
     function file(bytes32 what, address data) external auth {

--- a/src/pools/D3MAavePool.sol
+++ b/src/pools/D3MAavePool.sol
@@ -87,12 +87,13 @@ contract D3MAavePool is ID3MPool {
     event Collect(address indexed king, address indexed gift, uint256 amt);
 
     constructor(address hub_, address dai_, address pool_) {
-        pool = LendingPoolLike(pool_);
         dai = TokenLike(dai_);
+        pool = LendingPoolLike(pool_);
 
         // Fetch the reserve data from Aave
-        (,,,,,,, address adai_, address stableDebt_, address variableDebt_, ,) = pool.getReserveData(dai_);
-        require(stableDebt_ != address(0), "D3MAavePool/invalid-stableDebt");
+        (,,,,,,, address adai_, address stableDebt_, address variableDebt_,,) = pool.getReserveData(dai_);
+        require(adai_         != address(0), "D3MAavePool/invalid-adai");
+        require(stableDebt_   != address(0), "D3MAavePool/invalid-stableDebt");
         require(variableDebt_ != address(0), "D3MAavePool/invalid-variableDebt");
 
         adai = ATokenLike(adai_);


### PR DESCRIPTION
The following PR fixes two of the four inconsistencies brought up by ChainSecurity in section `5.4`.

> The target interest rate is `barb` in the `D3MCompoundPlan` and `bar` in the `D3MAavePlan`.

We won't fix this, but it's worth leaving a general comment on.  Each plan and pool is a bespoke integration adapter that seeks to normalized differences in third-party interfaces and interactions between those protocols and the hub.  For this general reason, while we are in full agreement that consistency between adapters should be maximized, in some cases there must be differences in the function and variable interfaces between adapters.  In this particular case, `bar` is a per-year interest rate in `RAY` units, while `barb` is a per-block interest rate in `WAD` units.  To name these variables the same for consistency would likely cause spell crafters, risk, and governance to make a massive mistake in setting the target borrow rate in the future.  For this reason, we named them differently.  That is, they are deliberately inconsistent for safety and security reasons.

> The `D3MAavePool` does not validate that the aDAI address is non-zero while the `D3MAavePlan` does.

This was an oversight that is resolved in this PR.  Furthermore, formatting changes were made to make the code flow similar between the start of the two constructors.

> `file()` for `D3MCompoundPlan` validates the target interest rate against the maximum while the `D3MAavePlan` treats it as special case.

I think this is a good point, but others should weigh in (@gbalabasquer).  My second commit, which we can revert/change if needed, will bound the `bar` in `D3MAavePlan` from being filed beyond `100%`.  We did bound `barb` in the `D3MCompoundPlan` because it was using a wonky block based borrow rate, and that didn't feel intuitive to us.  In order to prevent spell crafters and governance from shooting themselves in the foot, we bound this per-block borrow rate.  That being said, our normal rates are per-second, and the AAVE borrow rate is normalized out to a per-year rate.  This also is non-standard for us, and while more intuitive, one could argue we should also bound it so as not to make mistakes.  Perhaps 100% is too low and we want to go higher, or perhaps this is intuitive enough and we don't want to bound it at all, either way, I would be interested in opinions here.

>  The `D3MCompoundPool` performs a `== `check after `deposit()` while the `D3MAavePool` performs a `>=` check.

We won't fix this one either.  I'll echo my response to the first issue here, but as mentioned there we should seek to be maximally consistent.  In this case, while a strict equality would be desired in the `D3MAavePool`, there is a `1 wei` rounding error that pops up based on the state from block-to-block.  To demonstrate this inconsistency, I changed the `>=` check to a strict equality `==` and found two blocks that produced different results (with and without the rounding error).  You can see the results and reproduce them with the following test:

```haskell
$ match=test_hit_debt_ceiling block=15283320 make test-forge
./test-forge.sh match="test_hit_debt_ceiling" block="15283320" match-test="" match-contract=""
[⠆] Compiling...
[⠒] Compiling 95 files with 0.8.15
[⠊] Solc 0.8.15 finished in 25.79s
Compiler run successful

Running 1 test for src/tests/integration/D3MCompound.t.sol:D3MCompoundTest
[PASS] test_hit_debt_ceiling() (gas: 755284)
Test result: ok. 1 passed; 0 failed; finished in 371.77ms

Running 1 test for src/tests/integration/D3MAave.t.sol:D3MAaveTest
[PASS] test_hit_debt_ceiling() (gas: 796307)
Test result: ok. 1 passed; 0 failed; finished in 393.68ms

$ match=test_hit_debt_ceiling block=15283419 make test-forge
./test-forge.sh match="test_hit_debt_ceiling" block="15283419" match-test="" match-contract=""
[⠆] Compiling...
[⠰] Compiling 95 files with 0.8.15
[⠑] Solc 0.8.15 finished in 25.65s
Compiler run successful

Running 1 test for src/tests/integration/D3MCompound.t.sol:D3MCompoundTest
[PASS] test_hit_debt_ceiling() (gas: 755284)
Test result: ok. 1 passed; 0 failed; finished in 322.61ms

Running 1 test for src/tests/integration/D3MAave.t.sol:D3MAaveTest
[FAIL. Reason: D3MAavePool/incorrect-adai-balance-received] test_hit_debt_ceiling() (gas: 600824)
Traces:
  [600824] D3MAaveTest::test_hit_debt_ceiling() 
    ├─ [14182] Vat::file(0x44442d4441492d41000000000000000000000000000000000000000000000000, 0x6c696e6500000000000000000000000000000000000000000000000000000000, 100000000000000000000000000000000000000000000000000) 
    │   ├─  emit topic 0: 0x1a0b287e00000000000000000000000000000000000000000000000000000000
    │   │       topic 1: 0x44442d4441492d41000000000000000000000000000000000000000000000000
    │   │       topic 2: 0x6c696e6500000000000000000000000000000000000000000000000000000000
    │   │       topic 3: 0x0000000000000000000000446c3b15f9926687d2c40534fdb564000000000000
    │   │           data: 0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000e01a0b287e44442d4441492d410000000000000000000000000000000000000000000000006c696e65000000000000000000000000000000000000000000000000000000000000000000000000000000446c3b15f9926687d2c40534fdb56400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
    │   └─ ← ()
    ├─ [24218] InitializableImmutableAdminUpgradeabilityProxy::getReserveData(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [staticcall]
    │   ├─ [19047] LendingPool::getReserveData(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [delegatecall]
    │   │   └─ ← ((18447685934079306374676), 1074666083390109518164521865, 1118645498856287736666253996, 4583684287813351255433648, 15329072579817795157272380, 107664536289908897578636190, 1659717086, 0x028171bca77440897b824ca71d1c56cac55b68a3, 0x778a13d3eeb110a4f7bb6529f99c000119a08e92, 0x6c3c78838c761c6ac7be9f59fe808ea2a6e4379d, 0xfffe32106a68aa3ed39ccce673b646423eeab62a, 9)
    │   └─ ← ((18447685934079306374676), 1074666083390109518164521865, 1118645498856287736666253996, 4583684287813351255433648, 15329072579817795157272380, 107664536289908897578636190, 1659717086, 0x028171bca77440897b824ca71d1c56cac55b68a3, 0x778a13d3eeb110a4f7bb6529f99c000119a08e92, 0x6c3c78838c761c6ac7be9f59fe808ea2a6e4379d, 0xfffe32106a68aa3ed39ccce673b646423eeab62a, 9)
    ├─ [3718] InitializableImmutableAdminUpgradeabilityProxy::getReserveData(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [staticcall]
    │   ├─ [3047] LendingPool::getReserveData(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [delegatecall]
    │   │   └─ ← ((18447685934079306374676), 1074666083390109518164521865, 1118645498856287736666253996, 4583684287813351255433648, 15329072579817795157272380, 107664536289908897578636190, 1659717086, 0x028171bca77440897b824ca71d1c56cac55b68a3, 0x778a13d3eeb110a4f7bb6529f99c000119a08e92, 0x6c3c78838c761c6ac7be9f59fe808ea2a6e4379d, 0xfffe32106a68aa3ed39ccce673b646423eeab62a, 9)
    │   └─ ← ((18447685934079306374676), 1074666083390109518164521865, 1118645498856287736666253996, 4583684287813351255433648, 15329072579817795157272380, 107664536289908897578636190, 1659717086, 0x028171bca77440897b824ca71d1c56cac55b68a3, 0x778a13d3eeb110a4f7bb6529f99c000119a08e92, 0x6c3c78838c761c6ac7be9f59fe808ea2a6e4379d, 0xfffe32106a68aa3ed39ccce673b646423eeab62a, 9)
    ├─ [26135] D3MAavePlan::file(0x6261720000000000000000000000000000000000000000000000000000000000, 1532907257981779515727) 
    │   ├─ emit File(what: 0x6261720000000000000000000000000000000000000000000000000000000000, data: 1532907257981779515727)
    │   └─ ← ()
    ├─ [466839] D3MHub::exec(0x44442d4441492d41000000000000000000000000000000000000000000000000) 
    │   ├─ [9094] Vat::ilks(0x44442d4441492d41000000000000000000000000000000000000000000000000) [staticcall]
    │   │   └─ ← 0x0000000000000000000000000000000000000000, 0x0000000000000000033b2e3c9fd0803ce8000000, 1000000000000000000000000000, 100000000000000000000000000000000000000000000000000, 0
    │   ├─ [257] D3MAavePool::preDebtChange(0x6578656300000000000000000000000000000000000000000000000000000000) 
    │   │   └─ ← ()
    │   ├─ [13751] D3MAavePool::assetBalance() [staticcall]
    │   │   ├─ [10586] InitializableImmutableAdminUpgradeabilityProxy::balanceOf(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea]) [staticcall]
    │   │   │   ├─ [5475] AToken::balanceOf(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea]) [delegatecall]
    │   │   │   │   ├─ [2356] InitializableImmutableAdminUpgradeabilityProxy::getReserveNormalizedIncome(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [staticcall]
    │   │   │   │   │   ├─ [1745] LendingPool::getReserveNormalizedIncome(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [delegatecall]
    │   │   │   │   │   │   └─ ← 1074666094324124703212753690
    │   │   │   │   │   └─ ← 1074666094324124703212753690
    │   │   │   │   └─ ← 0
    │   │   │   └─ ← 0
    │   │   └─ ← 0
    │   ├─ [395] Vat::live() [staticcall]
    │   │   └─ ← 1
    │   ├─ [9212] D3MAavePlan::active() [staticcall]
    │   │   ├─ [3718] InitializableImmutableAdminUpgradeabilityProxy::getReserveData(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [staticcall]
    │   │   │   ├─ [3047] LendingPool::getReserveData(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [delegatecall]
    │   │   │   │   └─ ← ((18447685934079306374676), 1074666083390109518164521865, 1118645498856287736666253996, 4583684287813351255433648, 15329072579817795157272380, 107664536289908897578636190, 1659717086, 0x028171bca77440897b824ca71d1c56cac55b68a3, 0x778a13d3eeb110a4f7bb6529f99c000119a08e92, 0x6c3c78838c761c6ac7be9f59fe808ea2a6e4379d, 0xfffe32106a68aa3ed39ccce673b646423eeab62a, 9)
    │   │   │   └─ ← ((18447685934079306374676), 1074666083390109518164521865, 1118645498856287736666253996, 4583684287813351255433648, 15329072579817795157272380, 107664536289908897578636190, 1659717086, 0x028171bca77440897b824ca71d1c56cac55b68a3, 0x778a13d3eeb110a4f7bb6529f99c000119a08e92, 0x6c3c78838c761c6ac7be9f59fe808ea2a6e4379d, 0xfffe32106a68aa3ed39ccce673b646423eeab62a, 9)
    │   │   ├─ [852] InitializableImmutableAdminUpgradeabilityProxy::ATOKEN_REVISION() [staticcall]
    │   │   │   ├─ [244] AToken::ATOKEN_REVISION() [delegatecall]
    │   │   │   │   └─ ← 2
    │   │   │   └─ ← 2
    │   │   └─ ← true
    │   ├─ [4753] Vat::urns(0x44442d4441492d41000000000000000000000000000000000000000000000000, D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea]) [staticcall]
    │   │   └─ ← 0, 0
    │   ├─ [2416] Vat::Line() [staticcall]
    │   │   └─ ← 14441715730410484348412966877840110901246447868543042129
    │   ├─ [2352] Vat::debt() [staticcall]
    │   │   └─ ← 7510548318055950306526377044735974666464046071921753321
    │   ├─ [44504] D3MAavePlan::getTargetAssets(0) [staticcall]
    │   │   ├─ [12085] InitializableImmutableAdminUpgradeabilityProxy::totalSupply() [staticcall]
    │   │   │   ├─ [6977] VariableDebtToken::totalSupply() [delegatecall]
    │   │   │   │   ├─ [3901] InitializableImmutableAdminUpgradeabilityProxy::getReserveNormalizedVariableDebt(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [staticcall]
    │   │   │   │   │   ├─ [3290] LendingPool::getReserveNormalizedVariableDebt(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [delegatecall]
    │   │   │   │   │   │   └─ ← 1118645536919005999711627761
    │   │   │   │   │   └─ ← 1118645536919005999711627761
    │   │   │   │   └─ ← 102029695548694452720958311
    │   │   │   └─ ← 102029695548694452720958311
    │   │   ├─ [13946] InitializableImmutableAdminUpgradeabilityProxy::totalSupply() [staticcall]
    │   │   │   ├─ [8838] StableDebtToken::totalSupply() [delegatecall]
    │   │   │   │   └─ ← 1908844818571457328455402
    │   │   │   └─ ← 1908844818571457328455402
    │   │   ├─ [2602] Dai::balanceOf(InitializableImmutableAdminUpgradeabilityProxy: [0x028171bca77440897b824ca71d1c56cac55b68a3]) [staticcall]
    │   │   │   └─ ← 235085680336437527320219621
    │   │   ├─ [242] DefaultReserveInterestRateStrategy::baseVariableBorrowRate() [staticcall]
    │   │   │   └─ ← 0
    │   │   ├─ [460] DefaultReserveInterestRateStrategy::getMaxVariableBorrowRate() [staticcall]
    │   │   │   └─ ← 790000000000000000000000000
    │   │   ├─ [265] DefaultReserveInterestRateStrategy::variableRateSlope1() [staticcall]
    │   │   │   └─ ← 40000000000000000000000000
    │   │   ├─ [220] DefaultReserveInterestRateStrategy::OPTIMAL_UTILIZATION_RATE() [staticcall]
    │   │   │   └─ ← 800000000000000000000000000
    │   │   └─ ← 3389903269501326125237138490657
    │   ├─ [251] D3MAavePool::maxDeposit() [staticcall]
    │   │   └─ ← 115792089237316195423570985008687907853269984665640564039457584007913129639935
    │   ├─ [29484] Vat::slip(0x44442d4441492d41000000000000000000000000000000000000000000000000, D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], 100000000000000000000000) 
    │   │   ├─  emit topic 0: 0x7cdd3fde00000000000000000000000000000000000000000000000000000000
    │   │   │       topic 1: 0x44442d4441492d41000000000000000000000000000000000000000000000000
    │   │   │       topic 2: 0x000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea
    │   │   │       topic 3: 0x00000000000000000000000000000000000000000000152d02c7e14af6800000
    │   │   │           data: 0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000e07cdd3fde44442d4441492d41000000000000000000000000000000000000000000000000000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea00000000000000000000000000000000000000000000152d02c7e14af680000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
    │   │   └─ ← ()
    │   ├─ [80957] Vat::frob(0x44442d4441492d41000000000000000000000000000000000000000000000000, D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], D3MHub: [0xce71065d4017f316ec606fe4422e11eb2c47c246], 100000000000000000000000, 100000000000000000000000) 
    │   │   ├─  emit topic 0: 0x7608870300000000000000000000000000000000000000000000000000000000
    │   │   │       topic 1: 0x44442d4441492d41000000000000000000000000000000000000000000000000
    │   │   │       topic 2: 0x000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea
    │   │   │       topic 3: 0x000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea
    │   │   │           data: 0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000e07608870344442d4441492d41000000000000000000000000000000000000000000000000000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea000000000000000000000000ce71065d4017f316ec606fe4422e11eb2c47c24600000000000000000000000000000000000000000000152d02c7e14af680000000000000000000000000000000000000000000000000152d02c7e14af680000000000000000000000000000000000000000000000000000000000000
    │   │   └─ ← ()
    │   ├─ [45361] DaiJoin::exit(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], 100000000000000000000000) 
    │   │   ├─ [10275] Vat::move(D3MHub: [0xce71065d4017f316ec606fe4422e11eb2c47c246], DaiJoin: [0x9759a6ac90977b93b58547b4a71c78317f391a28], 100000000000000000000000000000000000000000000000000) 
    │   │   │   ├─  emit topic 0: 0xbb35783b00000000000000000000000000000000000000000000000000000000
    │   │   │   │       topic 1: 0x000000000000000000000000ce71065d4017f316ec606fe4422e11eb2c47c246
    │   │   │   │       topic 2: 0x0000000000000000000000009759a6ac90977b93b58547b4a71c78317f391a28
    │   │   │   │       topic 3: 0x0000000000000000000000446c3b15f9926687d2c40534fdb564000000000000
    │   │   │   │           data: 0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000e0bb35783b000000000000000000000000ce71065d4017f316ec606fe4422e11eb2c47c2460000000000000000000000009759a6ac90977b93b58547b4a71c78317f391a280000000000000000000000446c3b15f9926687d2c40534fdb56400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
    │   │   │   └─ ← ()
    │   │   ├─ [31845] Dai::mint(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], 100000000000000000000000) 
    │   │   │   ├─ emit Transfer(from: 0x0000000000000000000000000000000000000000, to: D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], value: 100000000000000000000000)
    │   │   │   └─ ← ()
    │   │   ├─  emit topic 0: 0xef693bed00000000000000000000000000000000000000000000000000000000
    │   │   │       topic 1: 0x000000000000000000000000ce71065d4017f316ec606fe4422e11eb2c47c246
    │   │   │       topic 2: 0x000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea
    │   │   │       topic 3: 0x00000000000000000000000000000000000000000000152d02c7e14af6800000
    │   │   │           data: 0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000e0ef693bed000000000000000000000000185a4dc360ce69bdccee33b3784b0282f7961aea00000000000000000000000000000000000000000000152d02c7e14af6800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
    │   │   └─ ← ()
    │   ├─ [172068] D3MAavePool::deposit(100000000000000000000000) 
    │   │   ├─ [1205] InitializableImmutableAdminUpgradeabilityProxy::scaledBalanceOf(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea]) [staticcall]
    │   │   │   ├─ [594] AToken::scaledBalanceOf(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea]) [delegatecall]
    │   │   │   │   └─ ← 0
    │   │   │   └─ ← 0
    │   │   ├─ [163810] InitializableImmutableAdminUpgradeabilityProxy::deposit(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f], 100000000000000000000000, D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], 0) 
    │   │   │   ├─ [163187] LendingPool::deposit(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f], 100000000000000000000000, D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], 0) [delegatecall]
    │   │   │   │   ├─ [720] ValidationLogic::0eca322b(212aa9bd7b173642810e5e991e9e9ed2f6ac3087d28021b9f35fb9d1a8d1160e00000000000000000000000000000000000000000000152d02c7e14af6800000) [delegatecall]
    │   │   │   │   │   └─ ← ()
    │   │   │   │   ├─ [963] InitializableImmutableAdminUpgradeabilityProxy::scaledTotalSupply() [staticcall]
    │   │   │   │   │   ├─ [355] VariableDebtToken::scaledTotalSupply() [delegatecall]
    │   │   │   │   │   │   └─ ← 91208244418251116927016415
    │   │   │   │   │   └─ ← 91208244418251116927016415
    │   │   │   │   ├─ [3809] InitializableImmutableAdminUpgradeabilityProxy::getSupplyData() [staticcall]
    │   │   │   │   │   ├─ [3189] StableDebtToken::getSupplyData() [delegatecall]
    │   │   │   │   │   │   └─ ← 1908643797642081079420975, 1908844818571457328455402, 85194926203515657617638200, 1659678172
    │   │   │   │   │   └─ ← 1908643797642081079420975, 1908844818571457328455402, 85194926203515657617638200, 1659678172
    │   │   │   │   ├─ [34069] InitializableImmutableAdminUpgradeabilityProxy::mintToTreasury(383260756427587781, 1074666094324124703212753690) 
    │   │   │   │   │   ├─ [33458] AToken::mintToTreasury(383260756427587781, 1074666094324124703212753690) [delegatecall]
    │   │   │   │   │   │   ├─ [15654] InitializableImmutableAdminUpgradeabilityProxy::handleAction(0x464c71f6c2f760dda6093dcb91c24c39e5d6e18c, 315469261374845993418898571, 4784032896868331751744011) 
    │   │   │   │   │   │   │   ├─ [10537] StakedTokenIncentivesController::handleAction(0x464c71f6c2f760dda6093dcb91c24c39e5d6e18c, 315469261374845993418898571, 4784032896868331751744011) [delegatecall]
    │   │   │   │   │   │   │   │   └─ ← ()
    │   │   │   │   │   │   │   └─ ← ()
    │   │   │   │   │   │   ├─ emit Transfer(from: 0x0000000000000000000000000000000000000000, to: 0x464c71f6c2f760dda6093dcb91c24c39e5d6e18c, value: 383260756427587781)
    │   │   │   │   │   │   ├─ emit Mint(from: 0x464c71f6c2f760dda6093dcb91c24c39e5d6e18c, value: 383260756427587781, index: 1074666094324124703212753690)
    │   │   │   │   │   │   └─ ← ()
    │   │   │   │   │   └─ ← ()
    │   │   │   │   ├─ [3535] InitializableImmutableAdminUpgradeabilityProxy::getTotalSupplyAndAvgRate() [staticcall]
    │   │   │   │   │   ├─ [2924] StableDebtToken::getTotalSupplyAndAvgRate() [delegatecall]
    │   │   │   │   │   │   └─ ← 1908844818571457328455402, 85194926203515657617638200
    │   │   │   │   │   └─ ← 1908844818571457328455402, 85194926203515657617638200
    │   │   │   │   ├─ [963] InitializableImmutableAdminUpgradeabilityProxy::scaledTotalSupply() [staticcall]
    │   │   │   │   │   ├─ [355] VariableDebtToken::scaledTotalSupply() [delegatecall]
    │   │   │   │   │   │   └─ ← 91208244418251116927016415
    │   │   │   │   │   └─ ← 91208244418251116927016415
    │   │   │   │   ├─ [602] Dai::balanceOf(InitializableImmutableAdminUpgradeabilityProxy: [0x028171bca77440897b824ca71d1c56cac55b68a3]) [staticcall]
    │   │   │   │   │   └─ ← 235085680336437527320219621
    │   │   │   │   ├─ [15675] DefaultReserveInterestRateStrategy::calculateInterestRates(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f], 235185680336437527320219621, 1908844818571457328455402, 102029695548694452720958311, 85194926203515657617638200, 1000) [staticcall]
    │   │   │   │   │   ├─ [2559] LendingPoolAddressesProvider::getLendingRateOracle() [staticcall]
    │   │   │   │   │   │   └─ ← LendingRateOracle: [0x8a32f49ffba88aba6eff96f45d8bd1d4b3f35c7d]
    │   │   │   │   │   ├─ [2486] LendingRateOracle::getMarketBorrowRate(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [staticcall]
    │   │   │   │   │   │   └─ ← 100000000000000000000000000
    │   │   │   │   │   └─ ← 4581108980588515337046053, 107662276388839692777863727, 15324552777679385555727455
    │   │   │   │   ├─ emit ReserveDataUpdated(reserve: Dai: [0x6b175474e89094c44da98b954eedeac495271d0f], liquidityRate: 4581108980588515337046053, stableBorrowRate: 107662276388839692777863727, variableBorrowRate: 15324552777679385555727455, liquidityIndex: 1074666094324124703212753690, variableBorrowIndex: 1118645536919005999711627761)
    │   │   │   │   ├─ [6895] Dai::transferFrom(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], InitializableImmutableAdminUpgradeabilityProxy: [0x028171bca77440897b824ca71d1c56cac55b68a3], 100000000000000000000000) 
    │   │   │   │   │   ├─ emit Transfer(from: D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], to: InitializableImmutableAdminUpgradeabilityProxy: [0x028171bca77440897b824ca71d1c56cac55b68a3], value: 100000000000000000000000)
    │   │   │   │   │   └─ ← true
    │   │   │   │   ├─ [52336] InitializableImmutableAdminUpgradeabilityProxy::mint(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], 100000000000000000000000, 1074666094324124703212753690) 
    │   │   │   │   │   ├─ [51716] AToken::mint(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], 100000000000000000000000, 1074666094324124703212753690) [delegatecall]
    │   │   │   │   │   │   ├─ [25754] InitializableImmutableAdminUpgradeabilityProxy::handleAction(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], 315469261731478400872514957, 0) 
    │   │   │   │   │   │   │   ├─ [25137] StakedTokenIncentivesController::handleAction(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], 315469261731478400872514957, 0) [delegatecall]
    │   │   │   │   │   │   │   │   ├─ emit UserIndexUpdated(user: D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], asset: InitializableImmutableAdminUpgradeabilityProxy: [0x028171bca77440897b824ca71d1c56cac55b68a3], index: 38362649671899)
    │   │   │   │   │   │   │   │   └─ ← ()
    │   │   │   │   │   │   │   └─ ← ()
    │   │   │   │   │   │   ├─ emit Transfer(from: 0x0000000000000000000000000000000000000000, to: D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], value: 100000000000000000000000)
    │   │   │   │   │   │   ├─ emit Mint(from: D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], value: 100000000000000000000000, index: 1074666094324124703212753690)
    │   │   │   │   │   │   └─ ← true
    │   │   │   │   │   └─ ← true
    │   │   │   │   ├─ emit ReserveUsedAsCollateralEnabled(reserve: Dai: [0x6b175474e89094c44da98b954eedeac495271d0f], user: D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea])
    │   │   │   │   ├─ emit Deposit(reserve: Dai: [0x6b175474e89094c44da98b954eedeac495271d0f], user: D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], onBehalfOf: D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea], amount: 100000000000000000000000, referral: 0)
    │   │   │   │   └─ ← ()
    │   │   │   └─ ← ()
    │   │   ├─ [1482] InitializableImmutableAdminUpgradeabilityProxy::getReserveNormalizedIncome(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [staticcall]
    │   │   │   ├─ [871] LendingPool::getReserveNormalizedIncome(Dai: [0x6b175474e89094c44da98b954eedeac495271d0f]) [delegatecall]
    │   │   │   │   └─ ← 1074666094324124703212753690
    │   │   │   └─ ← 1074666094324124703212753690
    │   │   ├─ [1205] InitializableImmutableAdminUpgradeabilityProxy::scaledBalanceOf(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea]) [staticcall]
    │   │   │   ├─ [594] AToken::scaledBalanceOf(D3MAavePool: [0x185a4dc360ce69bdccee33b3784b0282f7961aea]) [delegatecall]
    │   │   │   │   └─ ← 93052158738563028178646
    │   │   │   └─ ← 93052158738563028178646
    │   │   └─ ← "D3MAavePool/incorrect-adai-balance-received"
    │   └─ ← "D3MAavePool/incorrect-adai-balance-received"
    └─ ← "D3MAavePool/incorrect-adai-balance-received"

Test result: FAILED. 0 passed; 1 failed; finished in 344.73ms

Failed tests:
[FAIL. Reason: D3MAavePool/incorrect-adai-balance-received] test_hit_debt_ceiling() (gas: 600824)

Encountered a total of 1 failing tests, 1 tests succeeded
make: *** [test-forge] Error 1
```