### PR TITLE
Support multiple cDai rate models and implementations

### DIFF
--- a/src/plans/D3MCompoundPlan.sol
+++ b/src/plans/D3MCompoundPlan.sol
@@ -79,10 +79,7 @@ contract D3MCompoundPlan is ID3MPlan {
     event Rely(address indexed usr);
     event Deny(address indexed usr);
     event File(bytes32 indexed what, uint256 data);
-    event AddTack(address indexed tack);
-    event RemoveTack(address indexed tack);
-    event AddDelegate(address indexed delegate);
-    event RemoveDelegate(address indexed delegate);
+    event File(bytes32 indexed what, address addr, uint256 data);
 
     constructor(address cDai_) {
         cDai = CErc20Like(cDai_);
@@ -131,26 +128,14 @@ contract D3MCompoundPlan is ID3MPlan {
         } else revert("D3MCompoundPlan/file-unrecognized-param");
         emit File(what, data);
     }
-
-    function addTack(address tack) external auth {
-        tacks[tack] = 1;
-        emit AddTack(tack);
+    function file(bytes32 what, address addr, uint256 data) external auth {
+        require(data == 0 || data == 1, "D3MCompoundPlan/file-invalid-data");
+        if (what == "tack") tacks[addr] = data;
+        else if (what == "delegate") delegates[addr] = data;
+        else revert("D3MCompoundPlan/file-unrecognized-param");
+        emit File(what, addr, data);
     }
 
-    function removeTack(address tack) external auth {
-        tacks[tack] = 0;
-        emit RemoveTack(tack);
-    }
-
-    function addDelegate(address delegate) external auth {
-        delegates[delegate] = 1;
-        emit AddDelegate(delegate);
-    }
-
-    function removeDelegate(address delegate) external auth {
-        delegates[delegate] = 0;
-        emit RemoveDelegate(delegate);
-    }
 
     function _calculateTargetSupply(uint256 targetInterestRate, uint256 borrows) internal view returns (uint256) {
         InterestRateModelLike tack = InterestRateModelLike(cDai.interestRateModel());

--- a/src/tests/plans/D3MCompoundPlan.t.sol
+++ b/src/tests/plans/D3MCompoundPlan.t.sol
@@ -53,6 +53,7 @@ contract D3MCompoundPlanWrapper is D3MCompoundPlan {
 contract D3MCompoundPlanTest is D3MPlanBaseTest {
     CErc20Like             cDai;
     InterestRateModelLike  model;
+    address                cDaiImplementation;
     D3MCompoundPlanWrapper plan;
 
     function _wmul(uint256 x, uint256 y) internal pure returns (uint256 z) {
@@ -98,9 +99,10 @@ contract D3MCompoundPlanTest is D3MPlanBaseTest {
 
         contractName = "D3MCompoundPlan";
 
-        dai   = DaiLike(0x6B175474E89094C44Da98b954EedeAC495271d0F);
-        cDai  = CErc20Like(0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643);
-        model = InterestRateModelLike(cDai.interestRateModel());
+        dai                = DaiLike(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+        cDai               = CErc20Like(0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643);
+        cDaiImplementation = cDai.implementation();
+        model              = InterestRateModelLike(cDai.interestRateModel());
 
         d3mTestPlan = address(new D3MCompoundPlanWrapper(address(cDai)));
         plan = D3MCompoundPlanWrapper(d3mTestPlan);
@@ -130,7 +132,11 @@ contract D3MCompoundPlanTest is D3MPlanBaseTest {
     }
 
     function test_sets_rateModel() public {
-        assertEq(address(model), address(plan.tack()));
+        assertEq(plan.tacks(address(model)), 1);
+    }
+
+    function test_sets_cdaiImplementation() public {
+        assertEq(plan.delegates(cDaiImplementation), 1);
     }
 
     function test_can_file_barb() public {
@@ -154,29 +160,48 @@ contract D3MCompoundPlanTest is D3MPlanBaseTest {
         assertRevert(d3mTestPlan, abi.encodeWithSignature("file(bytes32,uint256)", bytes32("barb"), uint256(1)), "D3MCompoundPlan/not-authorized");
     }
 
-    function test_can_file_rateModel() public {
-        assertEq(address(plan.tack()), address(model));
-
-        plan.file("tack", address(1));
-
-        assertEq(address(plan.tack()), address(1));
+    function test_can_add_rateModel() public {
+        assertEq(plan.tacks(address(1)), 0);
+        plan.addTack(address(1));
+        assertEq(plan.tacks(address(1)), 1);
     }
 
-    function test_can_file_delegate() public {
-        assertTrue(plan.delegate() != address(1));
-
-        plan.file("delegate", address(1));
-
-        assertEq(plan.delegate(), address(1));
+    function test_can_remove_rateModel() public {
+        assertEq(plan.tacks(address(model)), 1);
+        plan.removeTack(address(model));
+        assertEq(plan.tacks(address(model)), 0);
     }
 
-    function test_cannot_file_unknown_address_param() public {
-        assertRevert(d3mTestPlan, abi.encodeWithSignature("file(bytes32,address)", bytes32("bad"), address(1)), "D3MCompoundPlan/file-unrecognized-param");
+    function test_can_add_delegate() public {
+        assertEq(plan.delegates(address(1)), 0);
+        plan.addDelegate(address(1));
+        assertEq(plan.delegates(address(1)), 1);
     }
 
-    function test_cannot_file_address_without_auth() public {
+    function test_can_remove_delegate() public {
+        assertEq(plan.delegates(cDaiImplementation), 1);
+        plan.removeDelegate(cDaiImplementation);
+        assertEq(plan.delegates(cDaiImplementation), 0);
+    }
+
+    function test_cannot_add_tack_without_auth() public {
         plan.deny(address(this));
-        assertRevert(d3mTestPlan, abi.encodeWithSignature("file(bytes32,address)", bytes32("tack"), uint256(1)), "D3MCompoundPlan/not-authorized");
+        assertRevert(d3mTestPlan, abi.encodeWithSignature("addTack(address)", address(1)), "D3MCompoundPlan/not-authorized");
+    }
+
+    function test_cannot_remove_tack_without_auth() public {
+        plan.deny(address(this));
+        assertRevert(d3mTestPlan, abi.encodeWithSignature("removeTack(address)", address(1)), "D3MCompoundPlan/not-authorized");
+    }
+
+    function test_cannot_add_delegate_without_auth() public {
+        plan.deny(address(this));
+        assertRevert(d3mTestPlan, abi.encodeWithSignature("addDelegate(address)", address(1)), "D3MCompoundPlan/not-authorized");
+    }
+
+    function test_cannot_remove_delegate_without_auth() public {
+        plan.deny(address(this));
+        assertRevert(d3mTestPlan, abi.encodeWithSignature("removeDelegate(address)", address(1)), "D3MCompoundPlan/not-authorized");
     }
 
     function test_calculate_current_rate() public {
@@ -298,11 +323,12 @@ contract D3MCompoundPlanTest is D3MPlanBaseTest {
         plan.file("barb", 123);
 
         // Simulate Compound changing the rate model in the pool
-        assertTrue(address(plan.tack()) == cDai.interestRateModel());
+        assertEq(plan.tacks(cDai.interestRateModel()), 1);
         assertTrue(plan.active());
-        plan.file("tack", address(456));
+        plan.removeTack(cDai.interestRateModel());
+        plan.addTack(address(456));
 
-        assertTrue(address(plan.tack()) != cDai.interestRateModel());
+        assertEq(plan.tacks(cDai.interestRateModel()), 0);
         assertTrue(plan.active() == false);
     }
 
@@ -311,11 +337,12 @@ contract D3MCompoundPlanTest is D3MPlanBaseTest {
         plan.file("barb", 123);
 
         // Simulate Compound changing the cDai implementation
-        assertTrue(address(plan.delegate()) == cDai.implementation());
+        assertEq(plan.delegates(cDai.implementation()), 1);
         assertTrue(plan.active() == true);
-        plan.file("delegate", address(456));
+        plan.removeDelegate(cDai.implementation());
+        plan.addDelegate(address(456));
 
-        assertTrue(address(plan.delegate()) != cDai.implementation());
+        assertEq(plan.delegates(cDai.implementation()), 0);
         assertTrue(plan.active() == false);
     }
 
@@ -326,7 +353,13 @@ contract D3MCompoundPlanTest is D3MPlanBaseTest {
 
     function test_rate_model_not_changed_active() public {
         plan.file("barb", 123);
-        assertEq(address(plan.tack()), address(model));
+        assertEq(plan.tacks(address(model)), 1);
+        assertTrue(plan.active());
+    }
+
+    function test_delegate_not_changed_active() public {
+        plan.file("barb", 123);
+        assertEq(plan.delegates(cDaiImplementation), 1);
         assertTrue(plan.active());
     }
 
@@ -341,7 +374,8 @@ contract D3MCompoundPlanTest is D3MPlanBaseTest {
 
     function test_disable_without_auth() public {
         plan.file("barb", 123);
-        assertEq(address(plan.tack()), address(model));
+        assertEq(plan.tacks(address(model)), 1);
+        assertEq(plan.delegates(cDaiImplementation), 1);
         plan.deny(address(this));
 
         assertRevert(d3mTestPlan, abi.encodeWithSignature("disable()"), "D3MCompoundPlan/not-authorized");


### PR DESCRIPTION
This change adds the ability for the 3rd party (initially Compound) to upgrade their cDai rate model or cDai implementation without Maker having to unwind the d3m position. For that Maker governance would need to `addTack` and/or `addDelegate` with the new supported contract address, before the 3rd party change is made.

This change was not done in the past for the sake of simplicity / code convergence, and also since there were concerns for supporting the 3rd party to return to an old erroneous /malicious implementation. However, I think the concern is limited since in questionable scenarios Maker governance can always choose not to use this new ability and switch addresses the old way (while suffering some d3m downtime).

If this change is supported, an Aaave equivalent should be considered / implemented.