### PR TITLE
Add Aave Buffer Plan

### DIFF
--- a/script/D3MDeploy.s.sol
+++ b/script/D3MDeploy.s.sol
@@ -125,6 +125,16 @@ contract D3MDeployScript is Script {
             } else {
                 revert("Invalid pool type for rate target plan type");
             }
+        } else if (planType.eq("liquidity-buffer")) {
+            if (poolType.eq("aave")) {
+                d3m.plan = D3MDeploy.deployAaveBufferPlan(
+                    msg.sender,
+                    admin,
+                    config.readAddress("adai")
+                );
+            } else {
+                revert("Invalid pool type for rate target plan type");
+            }
         } else {
             revert("Unknown plan type");
         }

--- a/script/D3MInit.s.sol
+++ b/script/D3MInit.s.sol
@@ -28,7 +28,6 @@ import {
     D3MAavePoolConfig,
     D3MCompoundPoolConfig,
     D3MAavePlanConfig,
-    D3MAaveBufferPlanConfig,
     D3MCompoundPlanConfig,
     AavePoolLike,
     AavePlanLike,
@@ -145,20 +144,6 @@ contract D3MInitScript is Script {
                 D3MInit.initCompoundPlan(
                     d3m,
                     compoundCfg
-                );
-            } else {
-                revert("Invalid pool type for rate target plan type");
-            }
-        } else if (planType.eq("liquidity-buffer")) {
-            if (poolType.eq("aave")) {
-                D3MAaveBufferPlanConfig memory aaveCfg = D3MAaveBufferPlanConfig({
-                    buffer: config.readUint("buffer") * WAD,
-                    adai: AavePoolLike(d3m.pool).adai(),
-                    adaiRevision: AavePlanLike(d3m.plan).adaiRevision()
-                });
-                D3MInit.initAaveBufferPlan(
-                    d3m,
-                    aaveCfg
                 );
             } else {
                 revert("Invalid pool type for rate target plan type");

--- a/script/D3MInit.s.sol
+++ b/script/D3MInit.s.sol
@@ -28,6 +28,7 @@ import {
     D3MAavePoolConfig,
     D3MCompoundPoolConfig,
     D3MAavePlanConfig,
+    D3MAaveBufferPlanConfig,
     D3MCompoundPlanConfig,
     AavePoolLike,
     AavePlanLike,
@@ -144,6 +145,20 @@ contract D3MInitScript is Script {
                 D3MInit.initCompoundPlan(
                     d3m,
                     compoundCfg
+                );
+            } else {
+                revert("Invalid pool type for rate target plan type");
+            }
+        } else if (planType.eq("liquidity-buffer")) {
+            if (poolType.eq("aave")) {
+                D3MAaveBufferPlanConfig memory aaveCfg = D3MAaveBufferPlanConfig({
+                    buffer: config.readUint("buffer") * WAD,
+                    adai: AavePoolLike(d3m.pool).adai(),
+                    adaiRevision: AavePlanLike(d3m.plan).adaiRevision()
+                });
+                D3MInit.initAaveBufferPlan(
+                    d3m,
+                    aaveCfg
                 );
             } else {
                 revert("Invalid pool type for rate target plan type");

--- a/src/deploy/D3MDeploy.sol
+++ b/src/deploy/D3MDeploy.sol
@@ -25,6 +25,7 @@ import { D3MHub } from "../D3MHub.sol";
 import { D3MMom } from "../D3MMom.sol";
 import { D3MInstance } from "./D3MInstance.sol";
 import { D3MAavePlan } from "../plans/D3MAavePlan.sol";
+import { D3MAaveBufferPlan } from "../plans/D3MAaveBufferPlan.sol";
 import { D3MAavePool } from "../pools/D3MAavePool.sol";
 import { D3MCompoundPlan } from "../plans/D3MCompoundPlan.sol";
 import { D3MCompoundPool } from "../pools/D3MCompoundPool.sol";
@@ -92,6 +93,16 @@ library D3MDeploy {
         address lendingPool
     ) internal returns (address plan) {
         plan = address(new D3MAavePlan(version, dai, lendingPool));
+
+        ScriptTools.switchOwner(plan, deployer, owner);
+    }
+
+    function deployAaveBufferPlan(
+        address deployer,
+        address owner,
+        address adai
+    ) internal returns (address plan) {
+        plan = address(new D3MAaveBufferPlan(adai));
 
         ScriptTools.switchOwner(plan, deployer, owner);
     }

--- a/src/deploy/D3MInit.sol
+++ b/src/deploy/D3MInit.sol
@@ -47,6 +47,12 @@ interface AavePlanLike {
     function adaiRevision() external view returns (uint256);
 }
 
+interface AaveBufferPlanLike {
+    function file(bytes32, uint256) external;
+    function adai() external view returns (address);
+    function adaiRevision() external view returns (uint256);
+}
+
 interface ADaiLike {
     function ATOKEN_REVISION() external view returns (uint256);
 }
@@ -116,6 +122,12 @@ struct D3MAavePlanConfig {
     address stableDebt;
     address variableDebt;
     address tack;
+    uint256 adaiRevision;
+}
+
+struct D3MAaveBufferPlanConfig {
+    uint256 buffer;
+    address adai;
     uint256 adaiRevision;
 }
 
@@ -276,6 +288,21 @@ library D3MInit {
         require(adai.ATOKEN_REVISION() == aaveCfg.adaiRevision, "ADai adaiRevision mismatch");
 
         plan.file("bar", aaveCfg.bar);
+    }
+
+    function initAaveBufferPlan(
+        D3MInstance memory d3m,
+        D3MAaveBufferPlanConfig memory aaveCfg
+    ) internal {
+        AaveBufferPlanLike plan = AaveBufferPlanLike(d3m.plan);
+        ADaiLike adai = ADaiLike(aaveCfg.adai);
+
+        // Sanity checks
+        require(plan.adai() == address(adai), "Plan adai mismatch");
+        require(plan.adaiRevision() == aaveCfg.adaiRevision, "Plan adaiRevision mismatch");
+        require(adai.ATOKEN_REVISION() == aaveCfg.adaiRevision, "ADai adaiRevision mismatch");
+
+        plan.file("buffer", aaveCfg.buffer);
     }
 
     function initCompoundPlan(

--- a/src/plans/D3MAaveBufferPlan.sol
+++ b/src/plans/D3MAaveBufferPlan.sol
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.14;
+
+import "./ID3MPlan.sol";
+
+interface TokenLike {
+    function balanceOf(address) external view returns (uint256);
+}
+
+interface ATokenLike {
+    function UNDERLYING_ASSET_ADDRESS() external view returns (address);
+    function ATOKEN_REVISION() external view returns (uint256);
+}
+
+/**
+ *  @title D3M Aave Buffer Plan
+ *  @notice Ensure `buffer` amount of DAI is always available to borrow.
+ */
+contract D3MAaveBufferPlan is ID3MPlan {
+
+    mapping (address => uint256) public wards;
+    uint256                      public buffer;
+
+    TokenLike  public immutable dai;
+    ATokenLike public immutable adai;
+    uint256    public immutable adaiRevision;
+
+    // --- Events ---
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+    event File(bytes32 indexed what, uint256 data);
+
+    constructor(address adai_) {
+        adai = ATokenLike(adai_);
+        dai = TokenLike(adai.UNDERLYING_ASSET_ADDRESS());
+        adaiRevision = adai.ATOKEN_REVISION();
+        
+        wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+    }
+
+    modifier auth {
+        require(wards[msg.sender] == 1, "D3MAaveBufferPlan/not-authorized");
+        _;
+    }
+
+    // --- Admin ---
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
+
+    function file(bytes32 what, uint256 data) external auth {
+        if (what == "buffer") {
+            buffer = data;
+        } else revert("D3MAaveBufferPlan/file-unrecognized-param");
+        emit File(what, data);
+    }
+
+    function getTargetAssets(uint256 currentAssets) external override view returns (uint256) {
+        if (buffer == 0) return 0; // De-activated
+
+        uint256 liquidityAvailable = dai.balanceOf(address(adai));
+        if (buffer >= liquidityAvailable) {
+            // Need to increase liquidity
+            return currentAssets + (buffer - liquidityAvailable);
+        } else {
+            // Need to decrease liquidity
+            unchecked {
+                uint256 decrease = liquidityAvailable - buffer;
+                if (currentAssets >= decrease) {
+                    return currentAssets - decrease;
+                } else {
+                    return 0;
+                }
+            }
+        }
+    }
+
+    function active() public view override returns (bool) {
+        if (buffer == 0) return false;
+        uint256 adaiRevision_ = adai.ATOKEN_REVISION();
+        return adaiRevision_ == adaiRevision;
+    }
+
+    function disable() external override {
+        require(wards[msg.sender] == 1 || !active(), "D3MAaveBufferPlan/not-authorized");
+        buffer = 0;
+        emit Disable();
+    }
+}

--- a/src/tests/plans/D3MAaveBufferPlan.t.sol
+++ b/src/tests/plans/D3MAaveBufferPlan.t.sol
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.14;
+
+import { D3MPlanBaseTest, DaiLike } from "./D3MPlanBase.t.sol";
+import { D3MAaveBufferPlan } from "../../plans/D3MAaveBufferPlan.sol";
+
+contract ADaiMock {
+
+    address public dai;
+    uint256 public revision;
+
+    constructor(address _dai) {
+        dai = _dai;
+        revision = 1;
+    }
+
+    function setRevision(uint256 value) external {
+        revision = value;
+    }
+
+    function UNDERLYING_ASSET_ADDRESS() external view returns (address) {
+        return dai;
+    }
+
+    function ATOKEN_REVISION() external view returns (uint256) {
+        return revision;
+    }
+
+}
+
+contract DaiMock {
+
+    uint256 liquidity;
+
+    function setLiquidity(uint256 value) external {
+        liquidity = value;
+    }
+
+    function balanceOf(address) external view returns (uint256) {
+        return liquidity;
+    }
+
+}
+
+contract D3MAaveBufferPlanTest is D3MPlanBaseTest {
+
+    ADaiMock adai;
+    DaiMock  _dai;
+
+    D3MAaveBufferPlan plan;
+
+    event Disable();
+
+    function setUp() public override {
+        contractName = "D3MAaveBufferPlan";
+
+        dai = DaiLike(address(_dai = new DaiMock()));
+        adai = new ADaiMock(address(dai));
+
+        vm.expectEmit(true, true, true, true);
+        emit Rely(address(this));
+        d3mTestPlan = address(plan = new D3MAaveBufferPlan(address(adai)));
+    }
+
+    function test_constructor() public {
+        assertEq(address(plan.dai()), address(dai));
+        assertEq(address(plan.adai()), address(adai));
+        assertEq(plan.adaiRevision(), adai.revision());
+    }
+
+    function test_file() public {
+        checkFileUint(d3mTestPlan, contractName, ["buffer"]);
+    }
+
+    function test_auth_modifier() public {
+        plan.file("buffer", 1);
+        plan.deny(address(this));
+
+        checkModifier(d3mTestPlan, "D3MAaveBufferPlan/not-authorized", [
+            abi.encodeWithSelector(D3MAaveBufferPlan.disable.selector)
+        ]);
+    }
+
+    function test_implements_getTargetAssets() public override {
+        _dai.setLiquidity(40 ether);
+        plan.file("buffer", 100 ether);
+        assertEq(plan.getTargetAssets(0), 60 ether);
+    }
+
+    function test_increase_liquidity() public {
+        plan.file("buffer", 100 ether);
+        assertEq(plan.getTargetAssets(20 ether), 120 ether);
+    }
+
+    function test_decrease_liquidity_sole_provider() public {
+        plan.file("buffer", 100 ether);
+        assertEq(plan.getTargetAssets(0), 100 ether);
+        _dai.setLiquidity(100 ether);   // Simulate adding liquidity
+        _dai.setLiquidity(80 ether);    // Simulate someone borrowed 20 DAI
+        assertEq(plan.getTargetAssets(100 ether), 120 ether);
+        _dai.setLiquidity(100 ether);   // Topped back up to 100 DAI
+        _dai.setLiquidity(120 ether);   // User returned the 20 DAI
+        assertEq(plan.getTargetAssets(120 ether), 100 ether);
+        _dai.setLiquidity(100 ether);   // Liquidity goes back to 100 DAI
+    }
+
+    function test_decrease_liquidity_multiple_providers() public {
+        plan.file("buffer", 100 ether);
+        assertEq(plan.getTargetAssets(0), 100 ether);
+        _dai.setLiquidity(100 ether);   // Simulate adding liquidity
+        _dai.setLiquidity(150 ether);   // Someone else adds 50 DAI
+        assertEq(plan.getTargetAssets(100 ether), 50 ether);
+        _dai.setLiquidity(100 ether);   // Simulate removing liquidity
+        _dai.setLiquidity(300 ether);   // Someone else adds 200 DAI
+        assertEq(plan.getTargetAssets(50 ether), 0);    // Plan will remove all liquidity
+    }
+
+    function test_active_buffer_set() public {
+        assertEq(plan.buffer(), 0);
+        assertTrue(!plan.active());
+        plan.file("buffer", 1);
+        assertEq(plan.buffer(), 1);
+        assertTrue(plan.active());
+    }
+
+    function test_active_revision_changed() public {
+        plan.file("buffer", 1);
+        assertEq(plan.buffer(), 1);
+        assertEq(adai.revision(), 1);
+        assertTrue(plan.active());
+        adai.setRevision(2);
+        assertEq(adai.revision(), 2);
+        assertTrue(!plan.active());
+    }
+
+    function test_disable() public {
+        plan.file("buffer", 1);
+
+        assertEq(plan.buffer(), 1);
+        assertTrue(plan.active());
+        vm.expectEmit(true, true, true, true);
+        emit Disable();
+        plan.disable();
+        assertTrue(!plan.active());
+        assertEq(plan.buffer(), 0);
+    }
+
+    function test_disable_not_active() public {
+        plan.file("buffer", 1);
+        assertEq(plan.buffer(), 1);
+        assertEq(adai.revision(), 1);
+        assertTrue(plan.active());
+        adai.setRevision(2);
+        assertEq(adai.revision(), 2);
+        assertTrue(!plan.active());
+
+        plan.deny(address(this));
+
+        vm.expectEmit(true, true, true, true);
+        emit Disable();
+        plan.disable();
+        assertTrue(!plan.active());
+        assertEq(plan.buffer(), 0);
+    }
+    
+}


### PR DESCRIPTION
This targets a fixed liquidity amount in Aave. This will be useful to construct "pull"-style D3Ms in that liquidity is available as required by borrowers. It is not exactly a pull strategy, but effectively it is close enough. For example if you target a `buffer` of 10m DAI, Maker is the primary LP in the pool and outstanding debt is 200m then this will ensure that only 10m idle liquidity is sitting in the pool at any given time. In the above example total market size would be 210m.