### PR TITLE
update action version

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'
           java-package: jre
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 


### PR DESCRIPTION
Since node12 is deprecated we need to update the github action that uses it. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

cc @eskp @sanbotto @OleksandrUA @cristidas @jeannettemcd @zdumitru 