### PR TITLE
Add Debt Ceiling Plan

### DIFF
--- a/script/D3MDeploy.s.sol
+++ b/script/D3MDeploy.s.sol
@@ -116,6 +116,13 @@ contract D3MDeployScript is Script {
             } else {
                 revert("Invalid pool type for rate target plan type");
             }
+        } else if (planType.eq("debt-ceiling")) {
+            d3m.plan = D3MDeploy.deployDebtCeilingPlan(
+                msg.sender,
+                admin,
+                ilk,
+                address(dss.vat)
+            );
         } else {
             revert("Unknown plan type");
         }

--- a/script/D3MInit.s.sol
+++ b/script/D3MInit.s.sol
@@ -150,6 +150,12 @@ contract D3MInitScript is Script {
             } else {
                 revert("Invalid pool type for rate target plan type");
             }
+        } else if (planType.eq("debt-ceiling")) {
+            D3MInit.initDebtCeilingPlan(
+                dss,
+                d3m,
+                cfg
+            );
         } else {
             revert("Unknown plan type");
         }

--- a/src/deploy/D3MDeploy.sol
+++ b/src/deploy/D3MDeploy.sol
@@ -24,6 +24,7 @@ import { D3MCoreInstance } from "./D3MCoreInstance.sol";
 import { D3MHub } from "../D3MHub.sol";
 import { D3MMom } from "../D3MMom.sol";
 import { D3MInstance } from "./D3MInstance.sol";
+import { D3MDebtCeilingPlan } from "../plans/D3MDebtCeilingPlan.sol";
 import { D3MAaveV2TypeRateTargetPlan } from "../plans/D3MAaveV2TypeRateTargetPlan.sol";
 import { D3MAaveV2TypePool } from "../pools/D3MAaveV2TypePool.sol";
 import { D3MCompoundV2TypeRateTargetPlan } from "../plans/D3MCompoundV2TypeRateTargetPlan.sol";
@@ -79,6 +80,17 @@ library D3MDeploy {
         pool = address(new D3MCompoundV2TypePool(ilk, hub, cdai));
 
         ScriptTools.switchOwner(pool, deployer, owner);
+    }
+
+    function deployDebtCeilingPlan(
+        address deployer,
+        address owner,
+        bytes32 ilk,
+        address vat
+    ) internal returns (address plan) {
+        plan = address(new D3MDebtCeilingPlan(vat, ilk));
+
+        ScriptTools.switchOwner(plan, deployer, owner);
     }
 
     function deployAaveV2TypeRateTargetPlan(

--- a/src/deploy/D3MInit.sol
+++ b/src/deploy/D3MInit.sol
@@ -27,6 +27,11 @@ import { ID3MPool } from "../pools/ID3MPool.sol";
 import { D3MInstance } from "./D3MInstance.sol";
 import { D3MCoreInstance } from "./D3MCoreInstance.sol";
 
+interface DebtCeilingPlanLike {
+    function ilk() external view returns (bytes32);
+    function vat() external view returns (address);
+}
+
 interface D3MAavePoolLike {
     function hub() external view returns (address);
     function dai() external view returns (address);
@@ -257,6 +262,18 @@ library D3MInit {
         require(pool.cDai() == compoundCfg.cdai, "Pool cDai mismatch");
 
         pool.file("king", compoundCfg.king);
+    }
+
+    function initDebtCeilingPlan(
+        DssInstance memory dss,
+        D3MInstance memory d3m,
+        D3MCommonConfig memory cfg
+    ) internal view {
+        DebtCeilingPlanLike plan = DebtCeilingPlanLike(d3m.plan);
+
+        // Sanity checks
+        require(plan.vat() == address(dss.vat), "Plan vat mismatch");
+        require(plan.ilk() == cfg.ilk, "Plan ilk mismatch");
     }
 
     function initAaveRateTargetPlan(

--- a/src/plans/D3MDebtCeilingPlan.sol
+++ b/src/plans/D3MDebtCeilingPlan.sol
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.14;
+
+import "./ID3MPlan.sol";
+
+interface VatLike {
+    function ilks(bytes32) external view returns (uint256, uint256, uint256, uint256, uint256);
+}
+
+/**
+ *  @title D3M Debt Ceiling Plan
+ *  @notice Simplest plan implementation which targets the vat.line for an ilk.
+ */
+contract D3MDebtCeilingPlan is ID3MPlan {
+
+    mapping (address => uint256) public wards;
+    uint256                      public enabled;
+
+    VatLike public immutable vat;
+    bytes32 public immutable ilk;
+
+    uint256 constant RAY = 10 ** 27;
+
+    // --- Events ---
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+    event File(bytes32 indexed what, uint256 data);
+
+    constructor(address vat_, bytes32 ilk_) {
+        vat = VatLike(vat_);
+        ilk = ilk_;
+        enabled = 1;
+
+        wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+    }
+
+    modifier auth {
+        require(wards[msg.sender] == 1, "D3MDebtCeilingPlan/not-authorized");
+        _;
+    }
+
+    // --- Admin ---
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
+
+    function file(bytes32 what, uint256 data) external auth {
+        if (what == "enabled") {
+            require(data <= 1, "D3MDebtCeilingPlan/invalid-value");
+            enabled = data;
+        } else revert("D3MDebtCeilingPlan/file-unrecognized-param");
+        emit File(what, data);
+    }
+
+    function getTargetAssets(uint256) external override view returns (uint256) {
+        (,,, uint256 line,) = vat.ilks(ilk);
+        return line / RAY;
+    }
+
+    function active() public view override returns (bool) {
+        if (enabled == 0) return false;
+        (,,, uint256 line,) = vat.ilks(ilk);
+        return line > 0;
+    }
+
+    function disable() external override auth {
+        enabled = 0;
+        emit Disable();
+    }
+}

--- a/src/tests/plans/D3MDebtCeilingPlan.t.sol
+++ b/src/tests/plans/D3MDebtCeilingPlan.t.sol
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.14;
+
+import { D3MPlanBaseTest } from "./D3MPlanBase.t.sol";
+import { D3MDebtCeilingPlan } from "../../plans/D3MDebtCeilingPlan.sol";
+
+contract VatMock {
+
+    uint256 debtCeiling;
+
+    function setDebtCeiling(uint256 value) external {
+        debtCeiling = value;
+    }
+
+    function ilks(bytes32) external view returns (uint256, uint256, uint256, uint256, uint256) {
+        return (0, 0, 0, debtCeiling, 0);
+    }
+
+}
+
+contract D3MDebtCeilingPlanTest is D3MPlanBaseTest {
+
+    bytes32 ilk = "DIRECT-PROTOCOL-A";
+    VatMock vat;
+
+    D3MDebtCeilingPlan plan;
+
+    event Disable();
+
+    function setUp() public override {
+        contractName = "D3MDebtCeilingPlan";
+
+        vat = new VatMock();
+
+        vm.expectEmit(true, true, true, true);
+        emit Rely(address(this));
+        d3mTestPlan = address(plan = new D3MDebtCeilingPlan(address(vat), ilk));
+    }
+
+    function test_constructor() public {
+        assertEq(address(plan.vat()), address(vat));
+        assertEq(plan.ilk(), ilk);
+        assertEq(plan.enabled(), 1);
+    }
+
+    function test_file() public {
+        // File checks will increment the current value by 1 so
+        // just set it to 0 to start with so there is no revert.
+        plan.file("enabled", 0);
+        checkFileUint(d3mTestPlan, contractName, ["enabled"]);
+    }
+
+    function test_file_bad_value() public {
+        vm.expectRevert("D3MDebtCeilingPlan/invalid-value");
+        plan.file("enabled", 2);
+    }
+
+    function test_auth_modifier() public {
+        plan.deny(address(this));
+
+        checkModifier(d3mTestPlan, "D3MDebtCeilingPlan/not-authorized", [
+            abi.encodeWithSelector(D3MDebtCeilingPlan.disable.selector)
+        ]);
+    }
+
+    function test_implements_getTargetAssets() public override {
+        vat.setDebtCeiling(100 * RAD);
+        uint256 result = plan.getTargetAssets(456);
+
+        assertEq(result, 100 * WAD);
+    }
+
+    function test_active_no_debt_ceiling() public {
+        assertEq(plan.enabled(), 1);
+        assertTrue(!plan.active());
+        vat.setDebtCeiling(100 * RAD);
+        assertEq(plan.enabled(), 1);
+        assertTrue(plan.active());
+    }
+
+    function test_disable() public {
+        vat.setDebtCeiling(100 * RAD);
+
+        assertEq(plan.enabled(), 1);
+        assertTrue(plan.active());
+        vm.expectEmit(true, true, true, true);
+        emit Disable();
+        plan.disable();
+        assertTrue(!plan.active());
+        assertEq(plan.enabled(), 0);
+    }
+
+}


### PR DESCRIPTION
Simplest plan which just targets the debt ceiling. This will be useful for any investment where Maker wants to just target a certain amount like 500m or something. Examples are like MIP65, Ondo, Backed Finance, GUSD, etc.