### PR TITLE
Fix tests

### DIFF
--- a/src/tests/integration/D3MAaveV2.t.sol
+++ b/src/tests/integration/D3MAaveV2.t.sol
@@ -109,7 +109,7 @@ contract D3MAaveV2IntegrationTest is DssTest {
         stkAave = GemAbstract(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
         dai = DaiAbstract(0x6B175474E89094C44Da98b954EedeAC495271d0F);
         daiJoin = DaiJoinAbstract(0x9759A6Ac90977b93B58547b4A71c78317f391A28);
-        interestStrategy = InterestRateStrategyLike(0xfffE32106A68aA3eD39CcCE673B646423EEaB62a);
+        interestStrategy = InterestRateStrategyLike(0xab7f8ca781C736EB624A9E321cd043F8E6292C96);
         rewardsClaimer = RewardsClaimerLike(0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5);
         spot = SpotAbstract(0x65C79fcB50Ca1594B025960e539eD7A9a6D434A3);
         weth = GemAbstract(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);

--- a/src/tests/plans/D3MAaveV2TypeRateTargetPlan.t.sol
+++ b/src/tests/plans/D3MAaveV2TypeRateTargetPlan.t.sol
@@ -66,7 +66,7 @@ contract D3MAaveV2TypeRateTargetPlanTest is D3MPlanBaseTest {
         dai = DaiAbstract(0x6B175474E89094C44Da98b954EedeAC495271d0F);
         aavePool = LendingPoolLike(0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9);
         adai = GemAbstract(0x028171bCA77440897B824Ca71D1c56caC55b68A3);
-        interestStrategy = InterestRateStrategyLike(0xfffE32106A68aA3eD39CcCE673B646423EEaB62a);
+        interestStrategy = InterestRateStrategyLike(0xab7f8ca781C736EB624A9E321cd043F8E6292C96);
 
         plan = new D3MAaveV2TypeRateTargetPlanWrapper(address(dai), address(aavePool));
 


### PR DESCRIPTION
Aave changed the IRM of DAI on AaveV2 recently ([proposal](https://app.aave.com/governance/v3/proposal/?proposalId=3), [tx](https://etherscan.io/tx/0x32e0c2df50544c1756263bc7ea7eaabe569817bab825503f62fcf163ff1b5eda)), and it breaks the tests as its address is hardcoded in them. An other fix would have been to query the irm of DAI each time, but maybe you prefer keeping it like that.

nb: this [new irm](https://etherscan.io/address/0xab7f8ca781C736EB624A9E321cd043F8E6292C96#code) is not verified on Etherscan 🤔