### PR TITLE
Add aave pool adapter for usds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate
-[submodule "lib/nst"]
-	path = lib/nst
-	url = https://github.com/makerdao/nst

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate
+[submodule "lib/usds"]
+	path = lib/usds
+	url = https://github.com/makerdao/usds

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,6 @@
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate
-[submodule "lib/nst"]
-	path = lib/nst
-	url = https://github.com/makerdao/nst
+[submodule "lib/usds"]
+	path = lib/usds
+	url = https://github.com/makerdao/usds

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,6 @@
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate
-[submodule "lib/usds"]
-	path = lib/usds
-	url = https://github.com/makerdao/usds
+[submodule "lib/nst"]
+	path = lib/nst
+	url = https://github.com/makerdao/nst

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate
+[submodule "lib/nst"]
+	path = lib/nst
+	url = https://github.com/makerdao/nst

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,5 @@
 [profile.default]
-solc_version   = '0.8.14'
-verbosity      = 3
+solc_version   = '0.8.21'
 optimizer      = true
 optimizer_runs = 200
 

--- a/script/D3MDeploy.s.sol
+++ b/script/D3MDeploy.s.sol
@@ -95,6 +95,16 @@ contract D3MDeployScript is Script {
                 address(dss.dai),
                 config.readAddress(".lendingPool")
             );
+        } else if (poolType.eq("aave-v3-nst-no-supply-cap")) {
+            d3m.pool = D3MDeploy.deployAaveV3NSTNoSupplyCapTypePool(
+                msg.sender,
+                admin,
+                ilk,
+                hub,
+                config.readAddress(".nstJoin"),
+                address(dss.daiJoin),
+                config.readAddress(".lendingPool")
+            );
         } else if (poolType.eq("compound-v2")) {
             d3m.pool = D3MDeploy.deployCompoundV2TypePool(
                 msg.sender,

--- a/script/D3MDeploy.s.sol
+++ b/script/D3MDeploy.s.sol
@@ -95,13 +95,13 @@ contract D3MDeployScript is Script {
                 address(dss.dai),
                 config.readAddress(".lendingPool")
             );
-        } else if (poolType.eq("aave-v3-nst-no-supply-cap")) {
-            d3m.pool = D3MDeploy.deployAaveV3NSTNoSupplyCapTypePool(
+        } else if (poolType.eq("aave-v3-usds-no-supply-cap")) {
+            d3m.pool = D3MDeploy.deployAaveV3USDSNoSupplyCapTypePool(
                 msg.sender,
                 admin,
                 ilk,
                 hub,
-                config.readAddress(".nstJoin"),
+                config.readAddress(".usdsJoin"),
                 address(dss.daiJoin),
                 config.readAddress(".lendingPool")
             );

--- a/script/D3MInit.s.sol
+++ b/script/D3MInit.s.sol
@@ -26,12 +26,12 @@ import {
     D3MInstance,
     D3MCommonConfig,
     D3MAavePoolConfig,
-    D3MAaveNSTPoolConfig,
+    D3MAaveUSDSPoolConfig,
     D3MCompoundPoolConfig,
     D3MAaveRateTargetPlanConfig,
     D3MCompoundRateTargetPlanConfig,
     D3MAavePoolLike,
-    D3MAaveNSTPoolLike,
+    D3MAaveUSDSPoolLike,
     D3MAaveRateTargetPlanLike,
     D3MAaveBufferPlanLike,
     D3MAaveBufferPlanConfig,
@@ -112,16 +112,16 @@ contract D3MInitScript is Script {
                 cfg,
                 aaveCfg
             );
-        } else if (poolType.eq("aave-v3-nst-no-supply-cap")) {
-            D3MAaveNSTPoolConfig memory aaveCfg = D3MAaveNSTPoolConfig({
+        } else if (poolType.eq("aave-v3-usds-no-supply-cap")) {
+            D3MAaveUSDSPoolConfig memory aaveCfg = D3MAaveUSDSPoolConfig({
                 king: config.readAddress(".king"),
-                anst: D3MAaveNSTPoolLike(d3m.pool).anst(),
-                nstJoin: D3MAaveNSTPoolLike(d3m.pool).nstJoin(),
-                nst: D3MAaveNSTPoolLike(d3m.pool).nst(),
-                stableDebt: D3MAaveNSTPoolLike(d3m.pool).stableDebt(),
-                variableDebt: D3MAaveNSTPoolLike(d3m.pool).variableDebt()
+                ausds: D3MAaveUSDSPoolLike(d3m.pool).ausds(),
+                usdsJoin: D3MAaveUSDSPoolLike(d3m.pool).usdsJoin(),
+                usds: D3MAaveUSDSPoolLike(d3m.pool).usds(),
+                stableDebt: D3MAaveUSDSPoolLike(d3m.pool).stableDebt(),
+                variableDebt: D3MAaveUSDSPoolLike(d3m.pool).variableDebt()
             });
-            D3MInit.initAaveNSTPool(
+            D3MInit.initAaveUSDSPool(
                 dss,
                 d3m,
                 cfg,

--- a/script/D3MInit.s.sol
+++ b/script/D3MInit.s.sol
@@ -26,10 +26,12 @@ import {
     D3MInstance,
     D3MCommonConfig,
     D3MAavePoolConfig,
+    D3MAaveNSTPoolConfig,
     D3MCompoundPoolConfig,
     D3MAaveRateTargetPlanConfig,
     D3MCompoundRateTargetPlanConfig,
     D3MAavePoolLike,
+    D3MAaveNSTPoolLike,
     D3MAaveRateTargetPlanLike,
     D3MAaveBufferPlanLike,
     D3MAaveBufferPlanConfig,
@@ -105,6 +107,21 @@ contract D3MInitScript is Script {
                 variableDebt: D3MAavePoolLike(d3m.pool).variableDebt()
             });
             D3MInit.initAavePool(
+                dss,
+                d3m,
+                cfg,
+                aaveCfg
+            );
+        } else if (poolType.eq("aave-v3-nst-no-supply-cap")) {
+            D3MAaveNSTPoolConfig memory aaveCfg = D3MAaveNSTPoolConfig({
+                king: config.readAddress(".king"),
+                anst: D3MAaveNSTPoolLike(d3m.pool).anst(),
+                nstJoin: D3MAaveNSTPoolLike(d3m.pool).nstJoin(),
+                nst: D3MAaveNSTPoolLike(d3m.pool).nst(),
+                stableDebt: D3MAaveNSTPoolLike(d3m.pool).stableDebt(),
+                variableDebt: D3MAaveNSTPoolLike(d3m.pool).variableDebt()
+            });
+            D3MInit.initAaveNSTPool(
                 dss,
                 d3m,
                 cfg,

--- a/script/input/1/template-aave-v3-lido.json
+++ b/script/input/1/template-aave-v3-lido.json
@@ -1,9 +1,9 @@
 {
     "chainlog": "0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F",
     "admin": "0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB",
-    "poolType": "aave-v3-nst-no-supply-cap",
+    "poolType": "aave-v3-usds-no-supply-cap",
     "planType": "operator",
-    "ilk": "DIRECT-SPARK-AAVE-NST",
+    "ilk": "DIRECT-SPARK-AAVE-USDS",
     "existingIlk": false,
     "maxLine": 100000000,
     "gap": 100000000,

--- a/script/input/1/template-aave-v3-lido.json
+++ b/script/input/1/template-aave-v3-lido.json
@@ -1,0 +1,15 @@
+{
+    "chainlog": "0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F",
+    "admin": "0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB",
+    "poolType": "aave-v3-nst-no-supply-cap",
+    "planType": "operator",
+    "ilk": "DIRECT-SPARK-AAVE-NST",
+    "existingIlk": false,
+    "maxLine": 100000000,
+    "gap": 100000000,
+    "ttl": 86400,
+    "tau": 604800,
+    "lendingPool": "0x4e033931ad43597d96D6bcc25c280717730B58B1",
+    "king": "0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB",
+    "operator": "0x298b375f24CeDb45e936D7e21d6Eb05e344adFb5"
+}

--- a/src/deploy/D3MDeploy.sol
+++ b/src/deploy/D3MDeploy.sol
@@ -28,7 +28,7 @@ import { D3MAaveV2TypeRateTargetPlan } from "../plans/D3MAaveV2TypeRateTargetPla
 import { D3MAaveTypeBufferPlan } from "../plans/D3MAaveTypeBufferPlan.sol";
 import { D3MAaveV2TypePool } from "../pools/D3MAaveV2TypePool.sol";
 import { D3MAaveV3NoSupplyCapTypePool } from "../pools/D3MAaveV3NoSupplyCapTypePool.sol";
-import { D3MAaveV3NSTNoSupplyCapTypePool } from "../pools/D3MAaveV3NSTNoSupplyCapTypePool.sol";
+import { D3MAaveV3USDSNoSupplyCapTypePool } from "../pools/D3MAaveV3USDSNoSupplyCapTypePool.sol";
 import { D3MCompoundV2TypeRateTargetPlan } from "../plans/D3MCompoundV2TypeRateTargetPlan.sol";
 import { D3MCompoundV2TypePool } from "../pools/D3MCompoundV2TypePool.sol";
 import { D3M4626TypePool } from "../pools/D3M4626TypePool.sol";
@@ -87,16 +87,16 @@ library D3MDeploy {
         ScriptTools.switchOwner(pool, deployer, owner);
     }
 
-    function deployAaveV3NSTNoSupplyCapTypePool(
+    function deployAaveV3USDSNoSupplyCapTypePool(
         address deployer,
         address owner,
         bytes32 ilk,
         address hub,
-        address nstJoin,
+        address usdsJoin,
         address daiJoin,
         address lendingPool
     ) internal returns (address pool) {
-        pool = address(new D3MAaveV3NSTNoSupplyCapTypePool(ilk, hub, nstJoin, daiJoin, lendingPool));
+        pool = address(new D3MAaveV3USDSNoSupplyCapTypePool(ilk, hub, usdsJoin, daiJoin, lendingPool));
 
         ScriptTools.switchOwner(pool, deployer, owner);
     }

--- a/src/deploy/D3MDeploy.sol
+++ b/src/deploy/D3MDeploy.sol
@@ -28,6 +28,7 @@ import { D3MAaveV2TypeRateTargetPlan } from "../plans/D3MAaveV2TypeRateTargetPla
 import { D3MAaveTypeBufferPlan } from "../plans/D3MAaveTypeBufferPlan.sol";
 import { D3MAaveV2TypePool } from "../pools/D3MAaveV2TypePool.sol";
 import { D3MAaveV3NoSupplyCapTypePool } from "../pools/D3MAaveV3NoSupplyCapTypePool.sol";
+import { D3MAaveV3NSTNoSupplyCapTypePool } from "../pools/D3MAaveV3NSTNoSupplyCapTypePool.sol";
 import { D3MCompoundV2TypeRateTargetPlan } from "../plans/D3MCompoundV2TypeRateTargetPlan.sol";
 import { D3MCompoundV2TypePool } from "../pools/D3MCompoundV2TypePool.sol";
 import { D3M4626TypePool } from "../pools/D3M4626TypePool.sol";
@@ -82,6 +83,20 @@ library D3MDeploy {
         address lendingPool
     ) internal returns (address pool) {
         pool = address(new D3MAaveV3NoSupplyCapTypePool(ilk, hub, dai, lendingPool));
+
+        ScriptTools.switchOwner(pool, deployer, owner);
+    }
+
+    function deployAaveV3NSTNoSupplyCapTypePool(
+        address deployer,
+        address owner,
+        bytes32 ilk,
+        address hub,
+        address nstJoin,
+        address daiJoin,
+        address lendingPool
+    ) internal returns (address pool) {
+        pool = address(new D3MAaveV3NSTNoSupplyCapTypePool(ilk, hub, nstJoin, daiJoin, lendingPool));
 
         ScriptTools.switchOwner(pool, deployer, owner);
     }

--- a/src/deploy/D3MInit.sol
+++ b/src/deploy/D3MInit.sol
@@ -37,6 +37,20 @@ interface D3MAavePoolLike {
     function variableDebt() external view returns (address);
 }
 
+interface D3MAaveNSTPoolLike {
+    function hub() external view returns (address);
+    function dai() external view returns (address);
+    function ilk() external view returns (bytes32);
+    function vat() external view returns (address);
+    function file(bytes32, address) external;
+    function anst() external view returns (address);
+    function nstJoin() external view returns (address);
+    function nst() external view returns (address);
+    function daiJoin() external view returns (address);
+    function stableDebt() external view returns (address);
+    function variableDebt() external view returns (address);
+}
+
 interface D3MAaveRateTargetPlanLike {
     function rely(address) external;
     function file(bytes32, uint256) external;
@@ -128,6 +142,15 @@ struct D3MCommonConfig {
 struct D3MAavePoolConfig {
     address king;
     address adai;
+    address stableDebt;
+    address variableDebt;
+}
+
+struct D3MAaveNSTPoolConfig {
+    address king;
+    address anst;
+    address nstJoin;
+    address nst;
     address stableDebt;
     address variableDebt;
 }
@@ -269,6 +292,29 @@ library D3MInit {
         require(pool.vat() == address(dss.vat), "Pool vat mismatch");
         require(pool.dai() == address(dss.dai), "Pool dai mismatch");
         require(pool.adai() == aaveCfg.adai, "Pool adai mismatch");
+        require(pool.stableDebt() == aaveCfg.stableDebt, "Pool stableDebt mismatch");
+        require(pool.variableDebt() == aaveCfg.variableDebt, "Pool variableDebt mismatch");
+
+        pool.file("king", aaveCfg.king);
+    }
+
+    function initAaveNSTPool(
+        DssInstance memory dss,
+        D3MInstance memory d3m,
+        D3MCommonConfig memory cfg,
+        D3MAaveNSTPoolConfig memory aaveCfg
+    ) internal {
+        D3MAavePoolLike pool = D3MAavePoolLike(d3m.pool);
+
+        // Sanity checks
+        require(pool.hub() == cfg.hub, "Pool hub mismatch");
+        require(pool.ilk() == cfg.ilk, "Pool ilk mismatch");
+        require(pool.vat() == address(dss.vat), "Pool vat mismatch");
+        require(pool.nstJoin() == aaveCfg.nstJoin, "Pool nstJoin mismatch");
+        require(pool.nst() == aaveCfg.nst, "Pool nst mismatch");
+        require(pool.daiJoin() == address(dss.daiJoin), "Pool daiJoin mismatch");
+        require(pool.dai() == address(dss.dai), "Pool dai mismatch");
+        require(pool.anst() == aaveCfg.anst, "Pool anst mismatch");
         require(pool.stableDebt() == aaveCfg.stableDebt, "Pool stableDebt mismatch");
         require(pool.variableDebt() == aaveCfg.variableDebt, "Pool variableDebt mismatch");
 

--- a/src/deploy/D3MInit.sol
+++ b/src/deploy/D3MInit.sol
@@ -304,7 +304,7 @@ library D3MInit {
         D3MCommonConfig memory cfg,
         D3MAaveNSTPoolConfig memory aaveCfg
     ) internal {
-        D3MAavePoolLike pool = D3MAavePoolLike(d3m.pool);
+        D3MAaveNSTPoolLike pool = D3MAaveNSTPoolLike(d3m.pool);
 
         // Sanity checks
         require(pool.hub() == cfg.hub, "Pool hub mismatch");

--- a/src/deploy/D3MInit.sol
+++ b/src/deploy/D3MInit.sol
@@ -37,15 +37,15 @@ interface D3MAavePoolLike {
     function variableDebt() external view returns (address);
 }
 
-interface D3MAaveNSTPoolLike {
+interface D3MAaveUSDSPoolLike {
     function hub() external view returns (address);
     function dai() external view returns (address);
     function ilk() external view returns (bytes32);
     function vat() external view returns (address);
     function file(bytes32, address) external;
-    function anst() external view returns (address);
-    function nstJoin() external view returns (address);
-    function nst() external view returns (address);
+    function ausds() external view returns (address);
+    function usdsJoin() external view returns (address);
+    function usds() external view returns (address);
     function daiJoin() external view returns (address);
     function stableDebt() external view returns (address);
     function variableDebt() external view returns (address);
@@ -146,11 +146,11 @@ struct D3MAavePoolConfig {
     address variableDebt;
 }
 
-struct D3MAaveNSTPoolConfig {
+struct D3MAaveUSDSPoolConfig {
     address king;
-    address anst;
-    address nstJoin;
-    address nst;
+    address ausds;
+    address usdsJoin;
+    address usds;
     address stableDebt;
     address variableDebt;
 }
@@ -298,23 +298,23 @@ library D3MInit {
         pool.file("king", aaveCfg.king);
     }
 
-    function initAaveNSTPool(
+    function initAaveUSDSPool(
         DssInstance memory dss,
         D3MInstance memory d3m,
         D3MCommonConfig memory cfg,
-        D3MAaveNSTPoolConfig memory aaveCfg
+        D3MAaveUSDSPoolConfig memory aaveCfg
     ) internal {
-        D3MAaveNSTPoolLike pool = D3MAaveNSTPoolLike(d3m.pool);
+        D3MAaveUSDSPoolLike pool = D3MAaveUSDSPoolLike(d3m.pool);
 
         // Sanity checks
         require(pool.hub() == cfg.hub, "Pool hub mismatch");
         require(pool.ilk() == cfg.ilk, "Pool ilk mismatch");
         require(pool.vat() == address(dss.vat), "Pool vat mismatch");
-        require(pool.nstJoin() == aaveCfg.nstJoin, "Pool nstJoin mismatch");
-        require(pool.nst() == aaveCfg.nst, "Pool nst mismatch");
+        require(pool.usdsJoin() == aaveCfg.usdsJoin, "Pool usdsJoin mismatch");
+        require(pool.usds() == aaveCfg.usds, "Pool usds mismatch");
         require(pool.daiJoin() == address(dss.daiJoin), "Pool daiJoin mismatch");
         require(pool.dai() == address(dss.dai), "Pool dai mismatch");
-        require(pool.anst() == aaveCfg.anst, "Pool anst mismatch");
+        require(pool.ausds() == aaveCfg.ausds, "Pool ausds mismatch");
         require(pool.stableDebt() == aaveCfg.stableDebt, "Pool stableDebt mismatch");
         require(pool.variableDebt() == aaveCfg.variableDebt, "Pool variableDebt mismatch");
 

--- a/src/pools/D3MAaveV3NSTNoSupplyCapTypePool.sol
+++ b/src/pools/D3MAaveV3NSTNoSupplyCapTypePool.sol
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: © 2021 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.14;
+
+import "./ID3MPool.sol";
+
+interface TokenLike {
+    function balanceOf(address) external view returns (uint256);
+    function approve(address, uint256) external returns (bool);
+    function transfer(address, uint256) external returns (bool);
+}
+
+interface VatLike {
+    function live() external view returns (uint256);
+    function hope(address) external;
+    function nope(address) external;
+}
+
+interface D3mHubLike {
+    function vat() external view returns (address);
+    function end() external view returns (EndLike);
+}
+
+interface EndLike {
+    function Art(bytes32) external view returns (uint256);
+}
+
+// https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/tokenization/AToken.sol
+interface ATokenLike is TokenLike {
+    function scaledBalanceOf(address) external view returns (uint256);
+    function getIncentivesController() external view returns (address);
+}
+
+// https://github.com/aave/aave-v3-core/blob/master/contracts/protocol/pool/Pool.sol
+interface PoolLike {
+
+    // Need to use a struct as too many variables to return on the stack
+    struct ReserveData {
+        //stores the reserve configuration
+        uint256 configuration;
+        //the liquidity index. Expressed in ray
+        uint128 liquidityIndex;
+        //the current supply rate. Expressed in ray
+        uint128 currentLiquidityRate;
+        //variable borrow index. Expressed in ray
+        uint128 variableBorrowIndex;
+        //the current variable borrow rate. Expressed in ray
+        uint128 currentVariableBorrowRate;
+        //the current stable borrow rate. Expressed in ray
+        uint128 currentStableBorrowRate;
+        //timestamp of last update
+        uint40 lastUpdateTimestamp;
+        //the id of the reserve. Represents the position in the list of the active reserves
+        uint16 id;
+        //aToken address
+        address aTokenAddress;
+        //stableDebtToken address
+        address stableDebtTokenAddress;
+        //variableDebtToken address
+        address variableDebtTokenAddress;
+        //address of the interest rate strategy
+        address interestRateStrategyAddress;
+        //the current treasury balance, scaled
+        uint128 accruedToTreasury;
+        //the outstanding unbacked aTokens minted through the bridging feature
+        uint128 unbacked;
+        //the outstanding debt borrowed against this asset in isolation mode
+        uint128 isolationModeTotalDebt;
+    }
+    
+    function supply(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
+    function withdraw(address asset, uint256 amount, address to) external;
+    function getReserveNormalizedIncome(address asset) external view returns (uint256);
+    function getReserveData(address asset) external view returns (ReserveData memory);
+}
+
+// https://github.com/aave/aave-v3-periphery/blob/master/contracts/rewards/RewardsController.sol
+interface RewardsClaimerLike {
+    function claimRewards(address[] calldata assets, uint256 amount, address to, address reward) external returns (uint256);
+}
+
+interface JoinLike {
+    function dai() external view returns (address);
+    function nst() external view returns (address);
+    function join(address, uint256) external;
+    function exit(address, uint256) external;
+}
+
+contract D3MAaveV3NSTNoSupplyCapTypePool is ID3MPool {
+
+    mapping (address => uint256) public wards;
+    address                      public hub;
+    address                      public king; // Who gets the rewards
+    uint256                      public exited;
+
+    bytes32    public immutable ilk;
+    VatLike    public immutable vat;
+    PoolLike   public immutable pool;
+    ATokenLike public immutable stableDebt;
+    ATokenLike public immutable variableDebt;
+    ATokenLike public immutable anst;
+    JoinLike   public immutable nstJoin;
+    TokenLike  public immutable nst; // Asset
+    JoinLike   public immutable daiJoin;
+    TokenLike  public immutable dai;
+
+    // --- Events ---
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+    event File(bytes32 indexed what, address data);
+    event Collect(address indexed king, address indexed gift, uint256 amt);
+
+    constructor(bytes32 ilk_, address hub_, address nstJoin_, address daiJoin_, address pool_) {
+        ilk = ilk_;
+        nstJoin = JoinLike(nstJoin_);
+        nst = TokenLike(nstJoin.nst());
+        daiJoin = JoinLike(daiJoin_);
+        dai = TokenLike(daiJoin.dai());
+        pool = PoolLike(pool_);
+
+        // Fetch the reserve data from Aave
+        PoolLike.ReserveData memory data = pool.getReserveData(address(nst));
+        require(data.aTokenAddress               != address(0), "D3MAaveV3NoSupplyCapTypePool/invalid-anst");
+        require(data.stableDebtTokenAddress      != address(0), "D3MAaveV3NoSupplyCapTypePool/invalid-stableDebt");
+        require(data.variableDebtTokenAddress    != address(0), "D3MAaveV3NoSupplyCapTypePool/invalid-variableDebt");
+
+        anst = ATokenLike(data.aTokenAddress);
+        stableDebt = ATokenLike(data.stableDebtTokenAddress);
+        variableDebt = ATokenLike(data.variableDebtTokenAddress);
+
+        hub = hub_;
+        vat = VatLike(D3mHubLike(hub_).vat());
+        vat.hope(hub_);
+
+        nst.approve(pool_, type(uint256).max);
+        dai.approve(daiJoin_, type(uint256).max);
+        vat.hope(daiJoin_);
+        nst.approve(nstJoin_, type(uint256).max);
+        vat.hope(nstJoin_);
+
+        wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+    }
+
+    modifier auth {
+        require(wards[msg.sender] == 1, "D3MAaveV3NoSupplyCapTypePool/not-authorized");
+        _;
+    }
+
+    modifier onlyHub {
+        require(msg.sender == hub, "D3MAaveV3NoSupplyCapTypePool/only-hub");
+        _;
+    }
+
+    // --- Math ---
+    uint256 internal constant RAY = 10 ** 27;
+    function _rdiv(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = (x * RAY) / y;
+    }
+    function _min(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = x <= y ? x : y;
+    }
+
+    // --- Admin ---
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
+
+    function file(bytes32 what, address data) external auth {
+        require(vat.live() == 1, "D3MAaveV3NoSupplyCapTypePool/no-file-during-shutdown");
+        if (what == "hub") {
+            vat.nope(hub);
+            hub = data;
+            vat.hope(data);
+        } else if (what == "king") king = data;
+        else revert("D3MAaveV3NoSupplyCapTypePool/file-unrecognized-param");
+        emit File(what, data);
+    }
+
+    // Deposits NST to Aave in exchange for anst which is received by this contract
+    // Aave: https://docs.aave.com/developers/core-contracts/pool#supply
+    function deposit(uint256 wad) external override onlyHub {
+        daiJoin.join(address(this), wad);
+        nstJoin.exit(address(this), wad);
+
+        uint256 scaledPrev = anst.scaledBalanceOf(address(this));
+
+        pool.supply(address(nst), wad, address(this), 0);
+
+        // Verify the correct amount of anst shows up
+        uint256 interestIndex = pool.getReserveNormalizedIncome(address(nst));
+        uint256 scaledAmount = _rdiv(wad, interestIndex);
+        require(anst.scaledBalanceOf(address(this)) >= (scaledPrev + scaledAmount), "D3MAaveV3NoSupplyCapTypePool/incorrect-anst-balance-received");
+    }
+
+    // Withdraws NST from Aave in exchange for anst
+    // Aave: https://docs.aave.com/developers/core-contracts/pool#withdraw
+    function withdraw(uint256 wad) external override onlyHub {
+        uint256 prevNst = nst.balanceOf(address(this));
+
+        pool.withdraw(address(nst), wad, address(this));
+
+        require(nst.balanceOf(address(this)) == prevNst + wad, "D3MAaveV3NoSupplyCapTypePool/incorrect-nst-balance-received");
+
+        nstJoin.join(address(this), wad);
+        daiJoin.exit(msg.sender, wad);
+    }
+
+    function exit(address dst, uint256 wad) external override onlyHub {
+        uint256 exited_ = exited;
+        exited = exited_ + wad;
+        uint256 amt = wad * assetBalance() / (D3mHubLike(hub).end().Art(ilk) - exited_);
+        require(anst.transfer(dst, amt), "D3MAaveV3NoSupplyCapTypePool/transfer-failed");
+    }
+
+    function quit(address dst) external override auth {
+        require(vat.live() == 1, "D3MAaveV3NoSupplyCapTypePool/no-quit-during-shutdown");
+        require(anst.transfer(dst, anst.balanceOf(address(this))), "D3MAaveV3NoSupplyCapTypePool/transfer-failed");
+    }
+
+    function preDebtChange() external override {}
+
+    function postDebtChange() external override {}
+
+    // --- Balance of the underlying asset (NST)
+    function assetBalance() public view override returns (uint256) {
+        return anst.balanceOf(address(this));
+    }
+
+    function maxDeposit() external pure override returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function maxWithdraw() external view override returns (uint256) {
+        return _min(nst.balanceOf(address(anst)), assetBalance());
+    }
+
+    function redeemable() external view override returns (address) {
+        return address(anst);
+    }
+
+    // --- Collect any rewards ---
+    function collect(address gift) external returns (uint256 amt) {
+        require(king != address(0), "D3MAaveV3NoSupplyCapTypePool/king-not-set");
+
+        address[] memory assets = new address[](1);
+        assets[0] = address(anst);
+
+        RewardsClaimerLike rewardsClaimer = RewardsClaimerLike(anst.getIncentivesController());
+
+        amt = rewardsClaimer.claimRewards(assets, type(uint256).max, king, gift);
+        emit Collect(king, gift, amt);
+    }
+}

--- a/src/pools/D3MAaveV3USDSNoSupplyCapTypePool.sol
+++ b/src/pools/D3MAaveV3USDSNoSupplyCapTypePool.sol
@@ -215,11 +215,11 @@ contract D3MAaveV3USDSNoSupplyCapTypePool is ID3MPool {
     // Withdraws USDS from Aave in exchange for ausds
     // Aave: https://docs.aave.com/developers/core-contracts/pool#withdraw
     function withdraw(uint256 wad) external override onlyHub {
-        uint256 prevNst = usds.balanceOf(address(this));
+        uint256 prevUsds = usds.balanceOf(address(this));
 
         pool.withdraw(address(usds), wad, address(this));
 
-        require(usds.balanceOf(address(this)) == prevNst + wad, "D3MAaveV3NoSupplyCapTypePool/incorrect-usds-balance-received");
+        require(usds.balanceOf(address(this)) == prevUsds + wad, "D3MAaveV3NoSupplyCapTypePool/incorrect-usds-balance-received");
 
         usdsJoin.join(address(this), wad);
         daiJoin.exit(msg.sender, wad);

--- a/src/tests/integration/AaveV3.t.sol
+++ b/src/tests/integration/AaveV3.t.sol
@@ -20,8 +20,8 @@ import "./IntegrationBase.t.sol";
 
 import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 
-import { UsdsDeploy, UsdsInstance } from "lib/nst/deploy/UsdsDeploy.sol";
-import { UsdsInit } from "lib/nst/deploy/UsdsInit.sol";
+import { UsdsDeploy, UsdsInstance } from "lib/usds/deploy/UsdsDeploy.sol";
+import { UsdsInit } from "lib/usds/deploy/UsdsInit.sol";
 
 import { D3MOperatorPlan } from "../../plans/D3MOperatorPlan.sol";
 import { D3MAaveV3USDSNoSupplyCapTypePool } from "../../pools/D3MAaveV3USDSNoSupplyCapTypePool.sol";

--- a/src/tests/integration/AaveV3.t.sol
+++ b/src/tests/integration/AaveV3.t.sol
@@ -1,0 +1,399 @@
+// SPDX-FileCopyrightText: © 2021 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.14;
+
+import "./IntegrationBase.t.sol";
+
+import { D3MOperatorPlan } from "../../plans/D3MOperatorPlan.sol";
+import { D3MAaveV3NSTNoSupplyCapTypePool } from "../../pools/D3MAaveV3NSTNoSupplyCapTypePool.sol";
+
+interface PoolLike {
+
+    // Need to use a struct as too many variables to return on the stack
+    struct ReserveData {
+        //stores the reserve configuration
+        uint256 configuration;
+        //the liquidity index. Expressed in ray
+        uint128 liquidityIndex;
+        //the current supply rate. Expressed in ray
+        uint128 currentLiquidityRate;
+        //variable borrow index. Expressed in ray
+        uint128 variableBorrowIndex;
+        //the current variable borrow rate. Expressed in ray
+        uint128 currentVariableBorrowRate;
+        //the current stable borrow rate. Expressed in ray
+        uint128 currentStableBorrowRate;
+        //timestamp of last update
+        uint40 lastUpdateTimestamp;
+        //the id of the reserve. Represents the position in the list of the active reserves
+        uint16 id;
+        //aToken address
+        address aTokenAddress;
+        //stableDebtToken address
+        address stableDebtTokenAddress;
+        //variableDebtToken address
+        address variableDebtTokenAddress;
+        //address of the interest rate strategy
+        address interestRateStrategyAddress;
+        //the current treasury balance, scaled
+        uint128 accruedToTreasury;
+        //the outstanding unbacked aTokens minted through the bridging feature
+        uint128 unbacked;
+        //the outstanding debt borrowed against this asset in isolation mode
+        uint128 isolationModeTotalDebt;
+    }
+
+    function getReserveData(address asset) external view returns (ReserveData memory);
+    function supply(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
+    function borrow(address asset, uint256 amount, uint256 interestRateMode, uint16 referralCode, address onBehalfOf) external;
+    function repay(address asset, uint256 amount, uint256 rateMode, address onBehalfOf) external;
+    function withdraw(address asset, uint256 amount, address to) external;
+}
+
+contract AaveV3LidoTest is IntegrationBaseTest {
+
+    using stdJson for string;
+    using MCD for *;
+    using GodMode for *;
+    using ScriptTools for *;
+
+    address OPEREATOR = 0x298b375f24CeDb45e936D7e21d6Eb05e344adFb5;  // Gov. facilitator multisig
+
+    PoolLike aavePool;
+
+    D3MOperatorPlan plan;
+    D3MAaveV3NSTNoSupplyCapTypePool pool;
+
+    function setUp() public {
+        baseInit();
+
+        vm.createSelectFork(vm.envString("ETH_RPC_URL"), 20469508);  // Aug 6, 2024
+
+        // Setup NST
+        
+
+        aavePool = PoolLike(0x4e033931ad43597d96D6bcc25c280717730B58B1);
+
+        // Deploy
+        d3m.oracle = D3MDeploy.deployOracle(
+            address(this),
+            admin,
+            ilk,
+            address(dss.vat)
+        );
+        d3m.pool = D3MDeploy.deployAaveV3NSTNoSupplyCapTypePool(
+            address(this),
+            admin,
+            ilk,
+            address(hub),
+            address(nstJoin),
+            address(daiJoin),
+            address(sparkPool)
+        );
+        pool = D3MAaveV3NSTNoSupplyCapTypePool(d3m.pool);
+        d3m.plan = D3MDeploy.deployOperatorPlan(
+            address(this),
+            admin
+        );
+        plan = D3MOperatorPlan(d3m.plan);
+
+        // Init
+        vm.startPrank(admin);
+
+        D3MCommonConfig memory cfg = D3MCommonConfig({
+            hub: address(hub),
+            mom: address(mom),
+            ilk: ilk,
+            existingIlk: false,
+            maxLine: 100_000_000e45,
+            gap: 100_000_000e45,
+            ttl: 24 hours,
+            tau: 7 days
+        });
+        D3MInit.initCommon(
+            dss,
+            d3m,
+            cfg
+        );
+        D3MInit.initAavePool(
+            dss,
+            d3m,
+            cfg,
+            D3MAavePoolConfig({
+                king: admin,
+                adai: address(pool.adai()),
+                stableDebt: address(pool.stableDebt()),
+                variableDebt: address(pool.variableDebt())
+            })
+        );
+        D3MInit.initOperatorPlan(
+            d3m,
+            D3MOperatorPlanConfig({
+                operator: OPEREATOR
+            })
+        );
+
+        vm.stopPrank();
+
+        // Give us some DAI
+        dai.setBalance(address(this), buffer * 100000000);
+
+        // Deposit WETH into the pool
+        uint256 amt = 1_000_000 * WAD;
+        DSTokenAbstract weth = DSTokenAbstract(dss.getIlk("ETH", "A").gem);
+        weth.setBalance(address(this), amt);
+        weth.approve(address(sparkPool), type(uint256).max);
+        dai.approve(address(sparkPool), type(uint256).max);
+        sparkPool.supply(address(weth), amt, address(this), 0);
+
+        assertGt(getDebtCeiling(), 0);
+
+        // Recompute the dai interest rate strategy to ensure the new line is taken into account
+        daiInterestRateStrategy.recompute();
+
+        basePostSetup();
+    }
+
+    // --- Overrides ---
+    function adjustDebt(int256 deltaAmount) internal override {
+        if (deltaAmount == 0) return;
+
+        int256 newBuffer = int256(plan.buffer()) + deltaAmount;
+        vm.prank(admin); plan.file("buffer", newBuffer >= 0 ? uint256(newBuffer) : 0);
+        hub.exec(ilk);
+    }
+
+    function adjustLiquidity(int256 deltaAmount) internal override {
+        if (deltaAmount == 0) return;
+
+        if (deltaAmount > 0) {
+            // Supply to increase liquidity
+            uint256 amt = uint256(deltaAmount);
+            dai.setBalance(address(this), dai.balanceOf(address(this)) + amt);
+            sparkPool.supply(address(dai), amt, address(0), 0);
+        } else {
+            // Borrow to decrease liquidity
+            uint256 amt = uint256(-deltaAmount);
+            sparkPool.borrow(address(dai), amt, 2, 0, address(this));
+        }
+    }
+
+    function generateInterest() internal override {
+        // Generate interest by borrowing and repaying
+        uint256 performanceBonus = daiInterestRateStrategy.performanceBonus();
+        sparkPool.supply(address(dai), performanceBonus * 4, address(this), 0);
+        sparkPool.borrow(address(dai), performanceBonus * 2, 2, 0, address(this));
+        vm.warp(block.timestamp + 1 days);
+        sparkPool.repay(address(dai), performanceBonus * 2, 2, address(this));
+        sparkPool.withdraw(address(dai), performanceBonus * 4, address(this));
+    }
+
+    function getLiquidity() internal override view returns (uint256) {
+        return dai.balanceOf(address(adai));
+    }
+
+    // --- Helper functions ---
+    function getDebtCeiling() internal view returns (uint256) {
+        (,,, uint256 line,) = dss.vat.ilks(ilk);
+        return line;
+    }
+
+    function getDebt() internal view returns (uint256) {
+        (, uint256 art) = dss.vat.urns(ilk, address(pool));
+        return art;
+    }
+
+    function _divup(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        unchecked {
+            z = x != 0 ? ((x - 1) / y) + 1 : 0;
+        }
+    }
+
+    function getInterestRateStrategy(address asset) internal view returns (address) {
+        PoolLike.ReserveData memory data = sparkPool.getReserveData(asset);
+        return data.interestRateStrategyAddress;
+    }
+
+    function forceUpdateIndicies(address asset) internal {
+        // Do the flashloan trick to force update indicies
+        sparkPool.flashLoanSimple(address(this), asset, 1, "", 0);
+    }
+
+    function executeOperation(
+        address,
+        uint256,
+        uint256,
+        address,
+        bytes calldata
+    ) external pure returns (bool) {
+        // Flashloan callback just immediately returns
+        return true;
+    }
+
+    function getTotalAssets(address asset) internal view returns (uint256) {
+        // Assets = DAI Liquidity + Total Debt
+        PoolLike.ReserveData memory data = sparkPool.getReserveData(asset);
+        return dai.balanceOf(address(adai)) + ATokenLike(data.variableDebtTokenAddress).totalSupply() + ATokenLike(data.stableDebtTokenAddress).totalSupply();
+    }
+
+    function getTotalLiabilities(address asset) internal view returns (uint256) {
+        // Liabilities = spDAI Supply + Amount Accrued to Treasury
+        PoolLike.ReserveData memory data = sparkPool.getReserveData(asset);
+        return _divup((adai.scaledTotalSupply() + uint256(data.accruedToTreasury)) * data.liquidityIndex, RAY);
+    }
+
+    function getAccruedToTreasury(address asset) internal view returns (uint256) {
+        PoolLike.ReserveData memory data = sparkPool.getReserveData(asset);
+        return data.accruedToTreasury;
+    }
+
+    // --- Tests ---
+    function test_simple_wind_unwind() public {
+        setLiquidityToZero();
+
+        assertEq(getDebt(), 0);
+
+        hub.exec(ilk);
+        assertEq(getDebt(), buffer, "should wind up to the buffer");
+
+        // User borrows half the debt injected by the D3M
+        sparkPool.borrow(address(dai), buffer / 2, 2, 0, address(this));
+        assertEq(getDebt(), buffer);
+
+        hub.exec(ilk);
+        assertEq(getDebt(), buffer + buffer / 2, "should have 1.5x the buffer in debt");
+
+        // User repays half their debt
+        sparkPool.repay(address(dai), buffer / 4, 2, address(this));
+        assertEq(getDebt(), buffer + buffer / 2);
+
+        hub.exec(ilk);
+        assertEq(getDebt(), buffer + buffer / 2 - buffer / 4, "should be back down to 1.25x the buffer");
+    }
+
+    /**
+     * The DAI market is using a new interest model which over-allocates interest to the treasury.
+     * This is due to the reserve factor not being flexible enough to account for this.
+     * Confirm that we can later correct the discrepancy by donating the excess liabilities back to the DAI pool. (This can be automated later on)
+     */
+    function test_asset_liabilities_fix() public {
+        uint256 assets = getTotalAssets(address(dai));
+        uint256 liabilities = getTotalLiabilities(address(dai));
+        if (assets >= liabilities) {
+            // Force the assets to become less than the liabilities
+            uint256 performanceBonus = daiInterestRateStrategy.performanceBonus();
+            vm.prank(admin); plan.file("buffer", performanceBonus * 4);
+            hub.exec(ilk);
+            sparkPool.borrow(address(dai), performanceBonus * 2, 2, 0, address(this));  // Supply rate should now be above 0% (we are over-allocating)
+
+            // Warp so we gaurantee there is new interest
+            vm.warp(block.timestamp + 365 days);
+            forceUpdateIndicies(address(dai));
+
+            assets = getTotalAssets(address(dai));
+            liabilities = getTotalLiabilities(address(dai));
+            assertLe(assets, liabilities, "assets should be less than or equal to liabilities");
+        }
+
+        // Let's fix the accounting
+        uint256 delta = liabilities - assets;
+
+        // First trigger all spDAI owed to the treasury to be accrued
+        assertGt(getAccruedToTreasury(address(dai)), 0, "accrued to treasury should be greater than 0");
+        address[] memory toMint = new address[](1);
+        toMint[0] = address(dai);
+        sparkPool.mintToTreasury(toMint);
+        assertEq(getAccruedToTreasury(address(dai)), 0, "accrued to treasury should be 0");
+        assertGe(adai.balanceOf(address(treasury)), delta, "adai treasury should have more than the delta between liabilities and assets");
+
+        // Donate the excess liabilities back to the pool
+        // This will burn the liabilities while keeping the assets the same
+        vm.prank(admin); treasuryAdmin.transfer(address(treasury), address(adai), address(this), delta);
+        sparkPool.withdraw(address(dai), delta, address(adai));
+
+        assets = getTotalAssets(address(dai)) + 1;  // In case of rounding error we +1
+        liabilities = getTotalLiabilities(address(dai));
+        assertGe(assets, liabilities, "assets should be greater than or equal to liabilities");
+    }
+
+    function test_asset_liabilities_fix_full_utilization_flashloan() public {
+        uint256 assets = getTotalAssets(address(dai));
+        uint256 liabilities = getTotalLiabilities(address(dai));
+        if (assets >= liabilities) {
+            // Force the assets to become less than the liabilities
+            uint256 performanceBonus = daiInterestRateStrategy.performanceBonus();
+            vm.prank(admin); plan.file("buffer", performanceBonus * 4);
+            hub.exec(ilk);
+            sparkPool.borrow(address(dai), performanceBonus * 2, 2, 0, address(this));  // Supply rate should now be above 0% (we are over-allocating)
+
+            // Warp so we gaurantee there is new interest
+            vm.warp(block.timestamp + 365 days);
+            forceUpdateIndicies(address(dai));
+
+            assets = getTotalAssets(address(dai));
+            liabilities = getTotalLiabilities(address(dai));
+            assertLe(assets, liabilities, "assets should be less than or equal to liabilities");
+        }
+
+        // Let's fix the accounting
+        uint256 delta = liabilities - assets;
+
+        // First trigger all spDAI owed to the treasury to be accrued
+        assertGt(getAccruedToTreasury(address(dai)), 0, "accrued to treasury should be greater than 0");
+        address[] memory toMint = new address[](1);
+        toMint[0] = address(dai);
+        sparkPool.mintToTreasury(toMint);
+        assertEq(getAccruedToTreasury(address(dai)), 0, "accrued to treasury should be 0");
+        assertGe(adai.balanceOf(address(treasury)), delta, "adai treasury should have more than the delta between liabilities and assets");
+
+        // Donate the excess liabilities back to the pool
+        // This will burn the liabilities while keeping the assets the same
+        vm.prank(admin); treasuryAdmin.transfer(address(treasury), address(adai), address(this), delta);
+
+        // Remove all DAI liquidity from the pool
+        sparkPool.borrow(address(dai), dai.balanceOf(address(adai)), 2, 0, address(this));
+        assertEq(dai.balanceOf(address(adai)), 0);
+        dai.setBalance(address(this), 0);       // We have no DAI as well
+
+        // Withdrawing won't work because no available DAI
+        vm.expectRevert();
+        sparkPool.withdraw(address(dai), delta, address(adai));
+
+        // Flash loan to close out the liabilities
+        flashLender.flashLoan(this, address(dai), delta, "");
+
+        assets = getTotalAssets(address(dai)) + 1;  // In case of rounding error we +1
+        liabilities = getTotalLiabilities(address(dai));
+        assertGe(assets, liabilities, "assets should be greater than or equal to liabilities");
+    }
+
+    function onFlashLoan(
+        address,
+        address token,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata
+    ) external returns (bytes32) {
+        sparkPool.supply(address(dai), amount, address(this), 0);
+        sparkPool.withdraw(address(dai), amount, address(adai));
+        sparkPool.withdraw(address(dai), amount, address(this));
+
+        ATokenLike(token).approve(address(msg.sender), amount + fee);
+
+        return keccak256("ERC3156FlashBorrower.onFlashLoan");
+    }
+}

--- a/src/tests/integration/AaveV3.t.sol
+++ b/src/tests/integration/AaveV3.t.sol
@@ -20,8 +20,8 @@ import "./IntegrationBase.t.sol";
 
 import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 
-import { UsdsDeploy, UsdsInstance } from "lib/usds/deploy/UsdsDeploy.sol";
-import { UsdsInit } from "lib/usds/deploy/UsdsInit.sol";
+import { UsdsDeploy, UsdsInstance } from "usds/deploy/UsdsDeploy.sol";
+import { UsdsInit } from "usds/deploy/UsdsInit.sol";
 
 import { D3MOperatorPlan } from "../../plans/D3MOperatorPlan.sol";
 import { D3MAaveV3USDSNoSupplyCapTypePool } from "../../pools/D3MAaveV3USDSNoSupplyCapTypePool.sol";

--- a/src/tests/integration/D3MAaveV2.t.sol
+++ b/src/tests/integration/D3MAaveV2.t.sol
@@ -70,7 +70,7 @@ interface RewardsClaimerLike {
     function getRewardsBalance(address[] calldata assets, address user) external view returns (uint256);
 }
 
-contract D3MAaveV2IntegrationTest is DssTest {
+abstract contract D3MAaveV2IntegrationTest is DssTest {
 
     using GodMode for *;
 

--- a/src/tests/plans/D3MAaveV2TypeRateTargetPlan.t.sol
+++ b/src/tests/plans/D3MAaveV2TypeRateTargetPlan.t.sol
@@ -47,6 +47,7 @@ contract D3MAaveV2TypeRateTargetPlanWrapper is D3MAaveV2TypeRateTargetPlan {
     }
 }
 
+// Made abstract because this is broken and Aave V2 is no longer support
 abstract contract D3MAaveV2TypeRateTargetPlanTest is D3MPlanBaseTest {
 
     DaiAbstract dai;

--- a/src/tests/plans/D3MAaveV2TypeRateTargetPlan.t.sol
+++ b/src/tests/plans/D3MAaveV2TypeRateTargetPlan.t.sol
@@ -47,7 +47,7 @@ contract D3MAaveV2TypeRateTargetPlanWrapper is D3MAaveV2TypeRateTargetPlan {
     }
 }
 
-contract D3MAaveV2TypeRateTargetPlanTest is D3MPlanBaseTest {
+abstract contract D3MAaveV2TypeRateTargetPlanTest is D3MPlanBaseTest {
 
     DaiAbstract dai;
     LendingPoolLike aavePool;

--- a/src/tests/pools/D3MAaveV3NSTNoSupplyCapTypePool.t.sol
+++ b/src/tests/pools/D3MAaveV3NSTNoSupplyCapTypePool.t.sol
@@ -1,0 +1,332 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.14;
+
+import "./D3MPoolBase.t.sol";
+
+import { D3MAaveV3NSTNoSupplyCapTypePool, PoolLike } from "../../pools/D3MAaveV3NSTNoSupplyCapTypePool.sol";
+
+interface RewardsClaimerLike {
+    function getRewardsBalance(address[] calldata assets, address user) external view returns (uint256);
+}
+
+contract AToken is TokenMock {
+    address public rewardsClaimer;
+
+    constructor(uint256 decimals_) TokenMock(decimals_) {
+        rewardsClaimer = address(new FakeRewardsClaimer());
+    }
+
+    function scaledBalanceOf(address who) external view returns (uint256) {
+        return balanceOf[who];
+    }
+
+    function getIncentivesController() external view returns (address) {
+        return rewardsClaimer;
+    }
+}
+
+contract FakeRewardsClaimer {
+    struct ClaimCall {
+        address[] assets;
+        uint256 amt;
+        address dst;
+        address reward;
+    }
+    ClaimCall public lastClaim;
+
+    function claimRewards(address[] calldata assets, uint256 amt, address dst, address reward) external returns (uint256) {
+        lastClaim = ClaimCall(
+            assets,
+            amt,
+            dst,
+            reward
+        );
+        return amt;
+    }
+
+    function getAssetsFromClaim() external view returns (address[] memory) {
+        return lastClaim.assets;
+    }
+}
+
+contract FakeLendingPool {
+
+    // Need to use a struct as too many variables to return on the stack
+    struct ReserveData {
+        //stores the reserve configuration
+        uint256 configuration;
+        //the liquidity index. Expressed in ray
+        uint128 liquidityIndex;
+        //the current supply rate. Expressed in ray
+        uint128 currentLiquidityRate;
+        //variable borrow index. Expressed in ray
+        uint128 variableBorrowIndex;
+        //the current variable borrow rate. Expressed in ray
+        uint128 currentVariableBorrowRate;
+        //the current stable borrow rate. Expressed in ray
+        uint128 currentStableBorrowRate;
+        //timestamp of last update
+        uint40 lastUpdateTimestamp;
+        //the id of the reserve. Represents the position in the list of the active reserves
+        uint16 id;
+        //aToken address
+        address aTokenAddress;
+        //stableDebtToken address
+        address stableDebtTokenAddress;
+        //variableDebtToken address
+        address variableDebtTokenAddress;
+        //address of the interest rate strategy
+        address interestRateStrategyAddress;
+        //the current treasury balance, scaled
+        uint128 accruedToTreasury;
+        //the outstanding unbacked aTokens minted through the bridging feature
+        uint128 unbacked;
+        //the outstanding debt borrowed against this asset in isolation mode
+        uint128 isolationModeTotalDebt;
+    }
+
+    address public anst;
+    address public nst;
+
+    struct DepositCall {
+        address asset;
+        uint256 amt;
+        address forWhom;
+        uint16 code;
+    }
+    DepositCall public lastDeposit;
+
+    struct WithdrawCall {
+        address asset;
+        uint256 amt;
+        address dst;
+    }
+    WithdrawCall public lastWithdraw;
+
+    constructor(address anst_, address nst_) {
+        anst = anst_;
+        nst = nst_;
+    }
+
+    function getReserveData(address) external view returns(
+        ReserveData memory result
+    ) {
+        result.aTokenAddress = anst;
+        result.stableDebtTokenAddress = address(2);
+        result.variableDebtTokenAddress = address(3);
+        result.interestRateStrategyAddress = address(4);
+    }
+
+    function supply(address asset, uint256 amt, address forWhom, uint16 code) external {
+        lastDeposit = DepositCall(
+            asset,
+            amt,
+            forWhom,
+            code
+        );
+        TokenMock(anst).mint(forWhom, amt);
+    }
+
+    function withdraw(address asset, uint256 amt, address dst) external {
+        lastWithdraw = WithdrawCall(
+            asset,
+            amt,
+            dst
+        );
+        TokenMock(asset).transfer(dst, amt);
+    }
+
+    function getReserveNormalizedIncome(address asset) external pure returns (uint256) {
+        asset;
+        return 10 ** 27;
+    }
+}
+
+contract DaiJoinMock {
+
+    TokenMock public dai;
+
+    constructor(TokenMock dai_) {
+        dai = dai_;
+    }
+
+    function join(address usr, uint256 amt) external {
+        dai.transferFrom(usr, address(this), amt);
+    }
+
+    function exit(address usr, uint256 amt) external {
+        dai.transfer(usr, amt);
+    }
+    
+}
+
+contract NstJoinMock {
+
+    TokenMock public nst;
+
+    constructor(TokenMock nst_) {
+        nst = nst_;
+    }
+
+    function join(address usr, uint256 amt) external {
+        nst.transferFrom(usr, address(this), amt);
+    }
+
+    function exit(address usr, uint256 amt) external {
+        nst.transfer(usr, amt);
+    }
+    
+}
+
+contract D3MAaveV3NSTNoSupplyCapTypePoolTest is D3MPoolBaseTest {
+
+    AToken anst;
+    FakeLendingPool aavePool;
+    DaiJoinMock daiJoin;
+    TokenMock nst;
+    NstJoinMock nstJoin;
+    
+    D3MAaveV3NSTNoSupplyCapTypePool pool;
+
+    function setUp() public {
+        baseInit("D3MAaveV3NoSupplyCapTypePool");
+
+        nst = new TokenMock(18);
+        anst = new AToken(18);
+        daiJoin = new DaiJoinMock(dai);
+        nstJoin = new NstJoinMock(nst);
+        anst.mint(address(this), 1_000_000 ether);
+        aavePool = new FakeLendingPool(address(anst), address(nst));
+        anst.rely(address(aavePool));
+
+        dai.mint(address(daiJoin), 1_000_000 ether);
+        nst.mint(address(nstJoin), 1_000_000 ether);
+
+        setPoolContract(pool = new D3MAaveV3NSTNoSupplyCapTypePool("", address(hub), address(nstJoin), address(daiJoin), address(aavePool)));
+    }
+
+    function test_constructor_sets_values() public {
+        assertEq(address(pool.nstJoin()), address(nstJoin));
+        assertEq(address(pool.nst()), address(nst));
+        assertEq(address(pool.daiJoin()), address(daiJoin));
+        assertEq(address(pool.dai()), address(dai));
+    }
+
+    function test_can_file_king() public {
+        assertEq(pool.king(), address(0));
+
+        pool.file("king", address(123));
+
+        assertEq(pool.king(), address(123));
+    }
+
+    function test_cannot_file_king_no_auth() public {
+        pool.deny(address(this));
+        assertRevert(address(pool), abi.encodeWithSignature("file(bytes32,address)", bytes32("king"), address(123)), "D3MAaveV3NoSupplyCapTypePool/not-authorized");
+    }
+
+    function test_cannot_file_king_vat_caged() public {
+        vat.cage();
+        assertRevert(address(pool), abi.encodeWithSignature("file(bytes32,address)", bytes32("king"), address(123)), "D3MAaveV3NoSupplyCapTypePool/no-file-during-shutdown");
+    }
+
+    function test_deposit_calls_lending_pool_deposit() public {
+        TokenMock(address(anst)).rely(address(aavePool));
+        dai.mint(address(pool), 1);
+        vm.prank(address(hub)); pool.deposit(1);
+        (address asset, uint256 amt, address dst, uint256 code) = FakeLendingPool(address(aavePool)).lastDeposit();
+        assertEq(asset, address(nst));
+        assertEq(amt, 1);
+        assertEq(dst, address(pool));
+        assertEq(code, 0);
+    }
+
+    function test_collect_claims_for_king() public {
+        address king = address(123);
+        address rewardsClaimer = anst.getIncentivesController();
+        pool.file("king", king);
+
+        pool.collect(address(456));
+
+        (uint256 amt, address dst, address reward) = FakeRewardsClaimer(rewardsClaimer).lastClaim();
+        address[] memory assets = FakeRewardsClaimer(rewardsClaimer).getAssetsFromClaim();
+
+        assertEq(address(anst), assets[0]);
+        assertEq(amt, type(uint256).max);
+        assertEq(dst, king);
+        assertEq(reward, address(456));
+    }
+
+    function test_collect_no_king() public {
+        assertEq(pool.king(), address(0));
+        assertRevert(address(pool), abi.encodeWithSignature("collect(address)", address(0)), "D3MAaveV3NoSupplyCapTypePool/king-not-set");
+    }
+
+    function test_redeemable_returns_anst() public {
+        assertEq(pool.redeemable(), address(anst));
+    }
+
+    function test_exit_anst() public {
+        uint256 tokens = anst.totalSupply();
+        anst.transfer(address(pool), tokens);
+        assertEq(anst.balanceOf(address(this)), 0);
+        assertEq(anst.balanceOf(address(pool)), tokens);
+
+        end.setArt(tokens);
+        vm.prank(address(hub)); pool.exit(address(this), tokens);
+
+        assertEq(anst.balanceOf(address(this)), tokens);
+        assertEq(anst.balanceOf(address(pool)), 0);
+    }
+
+    function test_quit_moves_balance() public {
+        uint256 tokens = anst.totalSupply();
+        anst.transfer(address(pool), tokens);
+        assertEq(anst.balanceOf(address(this)), 0);
+        assertEq(anst.balanceOf(address(pool)), tokens);
+
+        pool.quit(address(this));
+
+        assertEq(anst.balanceOf(address(this)), tokens);
+        assertEq(anst.balanceOf(address(pool)), 0);
+    }
+
+    function test_assetBalance_gets_anst_balanceOf_pool() public {
+        uint256 tokens = anst.totalSupply();
+        assertEq(pool.assetBalance(), 0);
+        assertEq(anst.balanceOf(address(pool)), 0);
+
+        anst.transfer(address(pool), tokens);
+
+        assertEq(pool.assetBalance(), tokens);
+        assertEq(anst.balanceOf(address(pool)), tokens);
+    }
+
+    function test_maxWithdraw_gets_available_assets_nstBal() public {
+        uint256 tokens = anst.totalSupply();
+        anst.transfer(address(pool), tokens);
+        assertEq(nst.balanceOf(address(anst)), 0);
+        assertEq(anst.balanceOf(address(pool)), tokens);
+
+        assertEq(pool.maxWithdraw(), 0);
+    }
+
+    function test_maxDeposit_returns_max_uint() public {
+        assertEq(pool.maxDeposit(), type(uint256).max);
+    }
+}

--- a/src/tests/pools/D3MAaveV3NSTNoSupplyCapTypePool.t.sol
+++ b/src/tests/pools/D3MAaveV3NSTNoSupplyCapTypePool.t.sol
@@ -256,6 +256,29 @@ contract D3MAaveV3NSTNoSupplyCapTypePoolTest is D3MPoolBaseTest {
         assertEq(code, 0);
     }
 
+    function test_withdraw_calls_lending_pool_withdraw() public {
+        // make sure we have Nst to withdraw
+        TokenMock(address(nst)).mint(address(aavePool), 1);
+
+        vm.prank(address(hub)); pool.withdraw(1);
+        (address asset, uint256 amt, address dst) = FakeLendingPool(address(aavePool)).lastWithdraw();
+        assertEq(asset, address(nst));
+        assertEq(amt, 1);
+        assertEq(dst, address(pool));
+    }
+
+    function test_withdraw_calls_lending_pool_withdraw_vat_caged() public {
+        // make sure we have Nst to withdraw
+        TokenMock(address(nst)).mint(address(aavePool), 1);
+
+        vat.cage();
+        vm.prank(address(hub)); pool.withdraw(1);
+        (address asset, uint256 amt, address dst) = FakeLendingPool(address(aavePool)).lastWithdraw();
+        assertEq(asset, address(nst));
+        assertEq(amt, 1);
+        assertEq(dst, address(pool));
+    }
+
     function test_collect_claims_for_king() public {
         address king = address(123);
         address rewardsClaimer = anst.getIncentivesController();

--- a/src/tests/pools/D3MAaveV3USDSNoSupplyCapTypePool.t.sol
+++ b/src/tests/pools/D3MAaveV3USDSNoSupplyCapTypePool.t.sol
@@ -175,7 +175,7 @@ contract DaiJoinMock {
     
 }
 
-contract NstJoinMock {
+contract UsdsJoinMock {
 
     TokenMock public usds;
 
@@ -199,7 +199,7 @@ contract D3MAaveV3USDSNoSupplyCapTypePoolTest is D3MPoolBaseTest {
     FakeLendingPool aavePool;
     DaiJoinMock daiJoin;
     TokenMock usds;
-    NstJoinMock usdsJoin;
+    UsdsJoinMock usdsJoin;
     
     D3MAaveV3USDSNoSupplyCapTypePool pool;
 
@@ -209,7 +209,7 @@ contract D3MAaveV3USDSNoSupplyCapTypePoolTest is D3MPoolBaseTest {
         usds = new TokenMock(18);
         ausds = new AToken(18);
         daiJoin = new DaiJoinMock(dai);
-        usdsJoin = new NstJoinMock(usds);
+        usdsJoin = new UsdsJoinMock(usds);
         ausds.mint(address(this), 1_000_000 ether);
         aavePool = new FakeLendingPool(address(ausds), address(usds));
         ausds.rely(address(aavePool));
@@ -257,7 +257,7 @@ contract D3MAaveV3USDSNoSupplyCapTypePoolTest is D3MPoolBaseTest {
     }
 
     function test_withdraw_calls_lending_pool_withdraw() public {
-        // make sure we have Nst to withdraw
+        // make sure we have Usds to withdraw
         TokenMock(address(usds)).mint(address(aavePool), 1);
 
         vm.prank(address(hub)); pool.withdraw(1);
@@ -268,7 +268,7 @@ contract D3MAaveV3USDSNoSupplyCapTypePoolTest is D3MPoolBaseTest {
     }
 
     function test_withdraw_calls_lending_pool_withdraw_vat_caged() public {
-        // make sure we have Nst to withdraw
+        // make sure we have Usds to withdraw
         TokenMock(address(usds)).mint(address(aavePool), 1);
 
         vat.cage();


### PR DESCRIPTION
Duplicated`D3MAaveV3NoSupplyCapTypePool`, but will swap DAI for USDS before depositing and after withdrawing. Recommend diffing the files to see what's changed.

Some Notes:

 * Disabled some Aave V2 tests because we aren't using them anymore, and they are failing.
 * Had to bump the solc version due to NST requirements.
 * I would diff the unit tests against the DAI version. I removed a few failing tests, but the unit tests provide limited coverage anyways. I think it's more important to review the integration tests.